### PR TITLE
add public version of address csv from level-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ This work is licensed under a [Creative Commons Attribution-NonCommercial-ShareA
 
 ## CSV Files
 
-[![Date Last Updated](https://oca-data.s3.amazonaws.com/public/last-updated-shield.png)](https://oca-data.s3.amazonaws.com/public/last-updated-date.txt)
+[![Date Last Updated](https://oca-2-dev.s3.amazonaws.com/public/last-updated-shield.png)](https://oca-2-dev.s3.amazonaws.com/public/last-updated-date.txt)
 
-* [`oca_index`](https://s3.amazonaws.com/oca-data/public/oca_index.csv)
-* [`oca_causes`](https://s3.amazonaws.com/oca-data/public/oca_causes.csv)
-* [`oca_addresses`](https://s3.amazonaws.com/oca-data/public/oca_addresses.csv)
-* [`oca_parties`](https://s3.amazonaws.com/oca-data/public/oca_parties.csv)
-* [`oca_events`](https://s3.amazonaws.com/oca-data/public/oca_events.csv)
-* [`oca_appearances`](https://s3.amazonaws.com/oca-data/public/oca_appearances.csv)
-* [`oca_appearance_outcomes`](https://s3.amazonaws.com/oca-data/public/oca_appearance_outcomes.csv)
-* [`oca_motions`](https://s3.amazonaws.com/oca-data/public/oca_motions.csv)
-* [`oca_decisions`](https://s3.amazonaws.com/oca-data/public/oca_decisions.csv)
-* [`oca_judgments`](https://s3.amazonaws.com/oca-data/public/oca_judgments.csv)
-* [`oca_warrants`](https://s3.amazonaws.com/oca-data/public/oca_warrants.csv)
+* [`oca_index`](https://s3.amazonaws.com/oca-2-dev/public/oca_index.csv)
+* [`oca_causes`](https://s3.amazonaws.com/oca-2-dev/public/oca_causes.csv)
+* [`oca_addresses`](https://s3.amazonaws.com/oca-2-dev/public/oca_addresses.csv)
+* [`oca_parties`](https://s3.amazonaws.com/oca-2-dev/public/oca_parties.csv)
+* [`oca_events`](https://s3.amazonaws.com/oca-2-dev/public/oca_events.csv)
+* [`oca_appearances`](https://s3.amazonaws.com/oca-2-dev/public/oca_appearances.csv)
+* [`oca_appearance_outcomes`](https://s3.amazonaws.com/oca-2-dev/public/oca_appearance_outcomes.csv)
+* [`oca_motions`](https://s3.amazonaws.com/oca-2-dev/public/oca_motions.csv)
+* [`oca_decisions`](https://s3.amazonaws.com/oca-2-dev/public/oca_decisions.csv)
+* [`oca_judgments`](https://s3.amazonaws.com/oca-2-dev/public/oca_judgments.csv)
+* [`oca_warrants`](https://s3.amazonaws.com/oca-2-dev/public/oca_warrants.csv)
 
 
 ## About the data

--- a/lib/sql/create_addresses_views.sql
+++ b/lib/sql/create_addresses_views.sql
@@ -56,6 +56,16 @@ AS SELECT o.indexnumberid,
    FROM oca_addresses o
      JOIN tracts t ON st_intersects(o.geom, t.geom);
 
+-- create a view equivalent to the level-1 version of "oca_addresses" table from
+-- the level-2 table, which can be made public (used for NYCDB) 
+CREATE OR REPLACE VIEW public.oca_addresses_public
+AS SELECT 
+	indexnumberid,
+    city,
+	state,
+	postalcode
+   FROM oca_addresses;
+
 -- Re grant access
 GRANT ALL ON ALL TABLES IN SCHEMA public TO jacob;
 GRANT ALL ON ALL TABLES IN SCHEMA public TO lucy;


### PR DESCRIPTION
To allow us to avoid creating a second scheduled job for processing level-1 data, we can create a level-1 equivalent export of the `oca_addresses` table from level-2 data. This PR modifies the new level-2 process to allow this by:
* renaming the level-2 (full address) version of `oca_addresses` csv export in s3 to `oca_addresses_private.csv`
* creating level-1 equivalent (zip only) version of `oca_addresses` csv export in s3 named `oca_addresses.csv` (for consistency with existing public files)
* update the remote-db loading to accomodate the name changes