### PR TITLE
fix bbl format in pluto table

### DIFF
--- a/lib/etl.py
+++ b/lib/etl.py
@@ -375,6 +375,8 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
         else:
             db.execute_sql_file('create_pluto_table.sql')
             db.import_csv('pluto', pluto_file)
+            
+        db.execute_sql_file('alter_pluto_table.sql')
 
     # TODO: setup census tracts if it does not exist 
             

--- a/lib/sql/alter_pluto_table.sql
+++ b/lib/sql/alter_pluto_table.sql
@@ -1,0 +1,4 @@
+
+alter table pluto alter column bbl TYPE TEXT USING (round(bbl::numeric,0));
+
+create index on pluto (bbl);

--- a/lib/sql/alter_pluto_table.sql
+++ b/lib/sql/alter_pluto_table.sql
@@ -1,4 +1,3 @@
+ALTER TABLE pluto ALTER COLUMN bbl TYPE TEXT USING (round(bbl::numeric,0));
 
-alter table pluto alter column bbl TYPE TEXT USING (round(bbl::numeric,0));
-
-create index on pluto (bbl);
+CREATE INDEX ON pluto (bbl);

--- a/lib/sql/create_addresses_views.sql
+++ b/lib/sql/create_addresses_views.sql
@@ -1,4 +1,4 @@
-CREATE OR REPLACE oca_addresses_with_bbl AS
+CREATE OR REPLACE VIEW public.oca_addresses_with_bbl AS
 	SELECT 
 		indexnumberid,
 		city,

--- a/lib/sql/create_pluto_table.sql
+++ b/lib/sql/create_pluto_table.sql
@@ -96,4 +96,3 @@ CREATE TABLE pluto (
 
 drop view if exists oca_addresses_with_bbl cascade;
 drop view if exists oca_addresses_with_ct cascade;
-alter table pluto alter column bbl TYPE TEXT USING (round(bbl::numeric,0));

--- a/lib/sql/create_tables.sql
+++ b/lib/sql/create_tables.sql
@@ -164,6 +164,7 @@ CREATE TABLE IF NOT EXISTS oca_warrants (
 
 CREATE INDEX ON oca_causes (indexnumberid);
 CREATE INDEX ON oca_addresses (indexnumberid);
+CREATE INDEX ON oca_addresses (bbl);
 CREATE INDEX ON oca_parties (indexnumberid);
 CREATE INDEX ON oca_events (indexnumberid);
 CREATE INDEX ON oca_appearances (indexnumberid);


### PR DESCRIPTION
I noticed that the `oca_addresses_with_bbl` table was missing bbl in all cases. It turns out that in the PLUTO csv bbl is formatted as a decimal (`1234567890.000000000`), and there is a step to alter the format to the standard 10-digit text field format, but this was done in the create table script, before the csv is imported, so it ends up with the decimals still just as text. I split out that part into a separate sql file (and added an index on bbl) so that it can be run after import. I also added an index on bbl for the addresses table, to hopefully speed up the join with pluto.