### PR TITLE
add parsers for street address fields

### DIFF
--- a/lib/parsers.py
+++ b/lib/parsers.py
@@ -157,6 +157,8 @@ def parse_addresses(case, db):
 
         rows.append({
             'indexnumberid' : IndexNumberId,
+            'street1' : oca_extract(address, 'Street1'),
+            'street2' : oca_extract(address, 'Street2'),
             'city' : oca_extract(address, 'City'),
             'state' : oca_extract(address, 'State'),
             'postalcode' : oca_extract(address, 'PostalCode'),


### PR DESCRIPTION
Somehow in the switch to this new branch for the address level (level 2) data we left out the additional street address fields in the XML parser. This adds them back in. 