### PR TITLE
Having staging run on local postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,21 @@ RUN apt-get install -y \
   rm -rf /var/lib/apt/lists/*
 
 # Check the latest version here https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gdelx.page
-ENV RELEASE=23d
-ENV MAJOR=23
-ENV MINOR=4
+# Copy the link to see the verison numbers
+# Example: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/linux_geo24c_24.3.zip
+# In the script set if statement under the comment '# setup pluto if it does not exist' to True
+# 
+# To manually update:
+# Upload pluto.csv to s3 and run ./lib/sql/create_pluto_table.sql, Then
+# SELECT aws_s3.table_import_from_s3(
+# 'pluto', '', '(FORMAT CSV, HEADER)',
+# aws_commons.create_s3_uri('oca-2-dev', 'public/pluto.csv', 'us-east-1'),
+# aws_commons.create_aws_credentials('id', 'key', '')
+# );
+# Lastly alter_pluto_table.sql
+ENV RELEASE=24c
+ENV MAJOR=24
+ENV MINOR=3
 ENV PATCH=0
 WORKDIR /geosupport
 
@@ -44,4 +56,4 @@ CMD ["python", "oca_update.py"]
 
 ENV PATH /var/pydev/bin:$PATH
 ENV PYTHONPATH /var/pydev
-ENV PYTHONUNBUFFERED yup
+ENV PYTHONUNBUFFERED 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NYC Housing Court Filings
 
+!!! This branch uses rds and s3 as the main database, and the local as stagging to avoid having to restore from .dumps
+
 The [Housing Data Coalition](https://www.housingdatanyc.org/) (HDC) has received housing court filings data from the New York State Office of Court Administration (OCA). In this repository we manage the Extract-Transform-Load (ETL) process for getting raw XML filings data from OCA via SFTP, parsing the nested XML data into a set of tables, and making those CSV files publicly available for download.
 
 To work with these data you can use the [NYCDB](https://github.com/nycdb/nycdb) to automatically load all of the tables into a PostgreSQL database for analysis. You can also find documentation about the data, including a [data dictionary](https://docs.google.com/spreadsheets/d/1GMDomQr8gEave6uLpLby9gQU0oMoGRL39kQdNbBJEqE) on the [NYCDB wiki](https://github.com/nycdb/nycdb/wiki/Dataset:-OCA-Housing-Court-Records).
@@ -61,17 +63,6 @@ To run the whole process in the docker container run:
 ```
 docker-compose run app
 ```
-
-### Modes
-
-This ETL process has two modes: Level 1 and Level 2. Level 1 accesses the SFTP for general OCA usage and produces an `oca_addresses` CSV file with a column for zipcode. Level 2 accesses a more restrictive SFTP and produces an `oca_addresses` CSV file with the building address columns (address without apartment or unit number) and an additional `oca_addresses_with_bbl` CSV file that only displays rows and data if the Borough-Block-Lot (BBL) or tax lot has 11 or more units. To switch between modes, edit the `MODE` variable in the .env file.
-
-Mode 1 can run on both SFTP Level 1 and Level 2, but Mode 2 can only run on the Level 2 SFTP. Additional security measures need to be put in place for the database, the `oca_addresses` table, and the CSV of the Level 2 data.
-
-Mode 2 adds PLUTO as an additional dataset and installs the matching version of [GeoSupport](https://www.nyc.gov/site/planning/data-maps/open-data/dwn-gde-home.page).
-
-You need to re-run `docker-compose build` when switching modes. To see echo outputs in your terminal for debugging, run `docker-compose build --progress=plain`.
-
 
 ### General rules for setting up a S3 Bucket
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,42 @@ services:
     user: 'root'
     volumes:
       - .:/app
+    depends_on: 
+      db:
+        condition: service_healthy
+    links:
+      - db
+  db:
+    image: postgres:15.3-alpine
+    environment:
+      - POSTGRES_DB=oca
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=oca
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB" ]
+      timeout: 5s
+      interval: 1s
+      retries: 20
+    command:
+      # See https://osm2pgsql.org/doc/manual.html#tuning-the-postgresql-server
+      - "postgres"
+      - "-c"
+      - "shared_buffers=256MB"
+      - "-c"
+      - "work_mem=25MB"
+      - "-c"
+      - "maintenance_work_mem=128MB"
+      - "-c"
+      - "wal_level=minimal"
+      - "-c"
+      - "max_wal_size=4GB"
+      - "-c"
+      - "checkpoint_completion_target=0.9"
+      - "-c"
+      - "max_wal_senders=0"
+      - "-c"
+      - "random_page_cost=1.0"
+      - "-c"
+      - "checkpoint_timeout=30min"

--- a/lib/etl.py
+++ b/lib/etl.py
@@ -371,6 +371,10 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
             ((pd.isna(df['lat'])) | (df['lat'] == '')) & 
             ((df['house_number'] != '') | (pd.notna(df['house_number'])))
         ].copy().reset_index()
+    
+    # # DEBUG: geocode all records
+    # df_1 = df
+
     print(f'Geocoding {len(df_1)} entries in {output_csv}.')
 
     records = df_1.to_dict('records')
@@ -462,7 +466,7 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
         db.sql(f"""
             SELECT aws_s3.table_import_from_s3(
             'pluto', '', '(FORMAT CSV, HEADER)',
-            aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/pluto.csv', 'us-east-1'),
+            aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/pluto_24v2.csv', 'us-east-1'),
             aws_commons.create_aws_credentials('{s3_args["aws_id"]}', '{s3_args["aws_key"]}', '')
         );
         """)

--- a/lib/etl.py
+++ b/lib/etl.py
@@ -111,17 +111,27 @@ def insert_staging_to_main(db):
     Delete all cases from main tables if they exist in the staging table, 
     then insert all records from the staging tables to the main tables
 
-    bug: DISABLE TRIGGER ALL to a work around to avoid DELETE FROM command stalling. 
-        A VACUUM FULL on all the tables were tried, it does not seem to helpl
-        Might be a database setting.
+    issue: SET session_replication_role = replica 
+        https://stackoverflow.com/questions/3942258/how-do-i-temporarily-disable-triggers-in-postgresql/18709987#18709987 
+        to a work around to avoid DELETE FROM command stalling. 
+        A VACUUM FULL on all the tables were tried, it does not seem to help
+        Might be an issue with the staging table schema?
 
     :param db: Database object
     """
 
-    db.sql(f"DELETE FROM oca_index WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging)")
+    db.sql("SET session_replication_role = replica;")
     for table in OCA_TABLES:
         if table in ('oca_metadata'): # skip these tables
-            continue 
+            continue
+        print(f"\t...Deleting older entries from {table}")
+        db.sql(f"DELETE FROM {table} WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging)")
+    db.sql("SET session_replication_role = default;")
+
+    for table in OCA_TABLES:
+        if table in ('oca_metadata'): # skip these tables
+            continue
+        print(f"\t...Inserting to {table}")
         db.sql(f"INSERT INTO {table} SELECT * FROM {table}_staging")
         db.sql(f"DROP TABLE {table}_staging")
 
@@ -277,17 +287,6 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
         with zipfile.ZipFile(zip_file, 'r').open(DATA_FILENAME) as xml_file:
             parse_file(xml_file, staging_db, extract_date)
 
-        # export staging tables, upload to s3, and then rds
-        staging_tables = [t + '_staging' for t in OCA_TABLES] + 'oca_metadata'
-
-        for t in staging_tables:
-            csv_filepath = os.path.join(pub_dir, f"{t}.csv")
-            db.export_csv(t, csv_filepath)
-        public_files = os.listdir(pub_dir)
-        with multiprocessing.Pool(processes=min((2, multiprocessing.cpu_count()))) as pool:
-            files_zip = zip(public_files, repeat(pub_dir), repeat(mode), repeat(s3_args)) 
-            pool.starmap(upload_public_file, files_zip) 
-        
         # reset staging tables
         db.execute_sql_file('create_tables_staging.sql')
         # reset metadata table (todo rework on oca_metadata table is parsed)
@@ -303,15 +302,29 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
                CREATE INDEX ON oca_metadata (indexnumberid);
 
         """) 
+
+        # # export staging tables, upload to s3, and then rds
+        staging_tables = [t + '_staging' for t in OCA_TABLES] + ['oca_metadata']
+        for t in staging_tables:
+            csv_filepath = os.path.join(pub_dir, f"{t}.csv")
+            staging_db.export_csv(t, csv_filepath)
+        public_files = os.listdir(pub_dir)
+        with multiprocessing.Pool(processes=min((2, multiprocessing.cpu_count()))) as pool:
+            files_zip = zip(public_files, repeat(pub_dir), repeat(mode), repeat(s3_args)) 
+            pool.starmap(upload_public_file, files_zip) 
+        
         for t in staging_tables:
             print('-', f"{t} table to db")
-            db.sql(f"""
-                SELECT aws_s3.table_import_from_s3(
-                '{t + '_staging'}', '', '(FORMAT CSV, HEADER)',
-                aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/{t}.csv', 'us-east-1'),
-                aws_commons.create_aws_credentials('{s3_args["aws_id"]}', '{s3_args["aws_key"]}', '')
-            );
-            """)
+            # only upload if csv has rows
+            csv_filepath = os.path.join(pub_dir, f"{t}.csv")
+            if len(pd.read_csv(csv_filepath)): # todo - rewrite not to use pandas (csv? or just read file lines using unix)
+                db.sql(f"""
+                    SELECT aws_s3.table_import_from_s3(
+                    '{t}', '', '(FORMAT CSV, HEADER)',
+                    aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/{t}.csv', 'us-east-1'),
+                    aws_commons.create_aws_credentials('{s3_args["aws_id"]}', '{s3_args["aws_key"]}', '')
+                );
+                """)
 
         print('\n   - Updating appearance outcomes...')
         db.execute_sql_file('update_appearance_outcomes.sql')

--- a/lib/etl.py
+++ b/lib/etl.py
@@ -195,6 +195,7 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
     """
 
     db = Database(**db_args)
+    staging_db = Database(db_url = 'postgres://postgres:oca@db/oca')
 
     sftp = Sftp(**sftp_args)
 
@@ -254,7 +255,13 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
         print('-', os.path.basename(zip_file))
 
         print('  - Creating staging tables...')
-        db.execute_sql_file('create_tables_staging.sql')
+        staging_db.execute_sql_file('create_tables.sql')
+        staging_db.execute_sql_file('create_tables_staging.sql')
+        # grab oca_metadata from s3 and import to staging_db (todo rework on this table is parsed)
+        csv_filepath = os.path.join(pub_dir, f"oca_metadata.csv")
+        db.export_csv('oca_metadata', csv_filepath)
+        staging_db.import_csv('oca_metadata', csv_filepath)
+        os.remove(csv_filepath) # clean up
 
         print('  - Parsing XML file...')
         extract_date = None
@@ -268,7 +275,26 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
                     break
 
         with zipfile.ZipFile(zip_file, 'r').open(DATA_FILENAME) as xml_file:
-            parse_file(xml_file, db, extract_date)
+            parse_file(xml_file, staging_db, extract_date)
+
+        # export staging tables, upload to s3, and then rds
+        for t in OCA_TABLES:
+            csv_filepath = os.path.join(pub_dir, f"{t + '_staging'}.csv")
+            db.export_csv(t + '_staging', csv_filepath)
+        public_files = os.listdir(pub_dir)
+        with multiprocessing.Pool(processes=min((2, multiprocessing.cpu_count()))) as pool:
+            files_zip = zip(public_files, repeat(pub_dir), repeat(mode), repeat(s3_args)) 
+            pool.starmap(upload_public_file, files_zip) 
+        db.execute_sql_file('create_tables_staging.sql')
+        for t in OCA_TABLES:
+            print('-', f"{t + '_staging'} table to db")
+            db.sql(f"""
+                SELECT aws_s3.table_import_from_s3(
+                '{t + '_staging'}', '', '(FORMAT CSV, HEADER)',
+                aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/{t + '_staging'}.csv', 'us-east-1'),
+                aws_commons.create_aws_credentials('{s3_args["aws_id"]}', '{s3_args["aws_key"]}', '')
+            );
+            """)
 
         print('\n   - Updating appearance outcomes...')
         db.execute_sql_file('update_appearance_outcomes.sql')

--- a/lib/etl.py
+++ b/lib/etl.py
@@ -257,7 +257,7 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
         print('  - Creating staging tables...')
         staging_db.execute_sql_file('create_tables.sql')
         staging_db.execute_sql_file('create_tables_staging.sql')
-        # grab oca_metadata from s3 and import to staging_db (todo rework on this table is parsed)
+        # grab oca_metadata from s3 and import to staging_db (todo rework on oca_metadata table is parsed)
         csv_filepath = os.path.join(pub_dir, f"oca_metadata.csv")
         db.export_csv('oca_metadata', csv_filepath)
         staging_db.import_csv('oca_metadata', csv_filepath)
@@ -278,20 +278,37 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
             parse_file(xml_file, staging_db, extract_date)
 
         # export staging tables, upload to s3, and then rds
-        for t in OCA_TABLES:
-            csv_filepath = os.path.join(pub_dir, f"{t + '_staging'}.csv")
-            db.export_csv(t + '_staging', csv_filepath)
+        staging_tables = [t + '_staging' for t in OCA_TABLES] + 'oca_metadata'
+
+        for t in staging_tables:
+            csv_filepath = os.path.join(pub_dir, f"{t}.csv")
+            db.export_csv(t, csv_filepath)
         public_files = os.listdir(pub_dir)
         with multiprocessing.Pool(processes=min((2, multiprocessing.cpu_count()))) as pool:
             files_zip = zip(public_files, repeat(pub_dir), repeat(mode), repeat(s3_args)) 
             pool.starmap(upload_public_file, files_zip) 
+        
+        # reset staging tables
         db.execute_sql_file('create_tables_staging.sql')
-        for t in OCA_TABLES:
-            print('-', f"{t + '_staging'} table to db")
+        # reset metadata table (todo rework on oca_metadata table is parsed)
+        db.sql("""
+            DROP TABLE IF EXISTS oca_metadata CASCADE;
+            CREATE TABLE IF NOT EXISTS oca_metadata (
+                indexnumberid text PRIMARY KEY,
+                initialdate date,
+                updatedate date,
+                deletedate date
+            );
+               
+               CREATE INDEX ON oca_metadata (indexnumberid);
+
+        """) 
+        for t in staging_tables:
+            print('-', f"{t} table to db")
             db.sql(f"""
                 SELECT aws_s3.table_import_from_s3(
                 '{t + '_staging'}', '', '(FORMAT CSV, HEADER)',
-                aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/{t + '_staging'}.csv', 'us-east-1'),
+                aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/{t}.csv', 'us-east-1'),
                 aws_commons.create_aws_credentials('{s3_args["aws_id"]}', '{s3_args["aws_key"]}', '')
             );
             """)

--- a/lib/etl.py
+++ b/lib/etl.py
@@ -111,17 +111,27 @@ def insert_staging_to_main(db):
     Delete all cases from main tables if they exist in the staging table, 
     then insert all records from the staging tables to the main tables
 
-    bug: DISABLE TRIGGER ALL to a work around to avoid DELETE FROM command stalling. 
-        A VACUUM FULL on all the tables were tried, it does not seem to helpl
-        Might be a database setting.
+    issue: SET session_replication_role = replica 
+        https://stackoverflow.com/questions/3942258/how-do-i-temporarily-disable-triggers-in-postgresql/18709987#18709987 
+        to a work around to avoid DELETE FROM command stalling. 
+        A VACUUM FULL on all the tables were tried, it does not seem to help
+        Might be an issue with the staging table schema?
 
     :param db: Database object
     """
 
-    db.sql(f"DELETE FROM oca_index WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging)")
+    db.sql("SET session_replication_role = replica;")
     for table in OCA_TABLES:
         if table in ('oca_metadata'): # skip these tables
-            continue 
+            continue
+        print(f"\t...Deleting older entries from {table}")
+        db.sql(f"DELETE FROM {table} WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging)")
+    db.sql("SET session_replication_role = default;")
+
+    for table in OCA_TABLES:
+        if table in ('oca_metadata'): # skip these tables
+            continue
+        print(f"\t...Inserting to {table}")
         db.sql(f"INSERT INTO {table} SELECT * FROM {table}_staging")
         db.sql(f"DROP TABLE {table}_staging")
 
@@ -277,17 +287,6 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
         with zipfile.ZipFile(zip_file, 'r').open(DATA_FILENAME) as xml_file:
             parse_file(xml_file, staging_db, extract_date)
 
-        # export staging tables, upload to s3, and then rds
-        staging_tables = [t + '_staging' for t in OCA_TABLES] + 'oca_metadata'
-
-        for t in staging_tables:
-            csv_filepath = os.path.join(pub_dir, f"{t}.csv")
-            db.export_csv(t, csv_filepath)
-        public_files = os.listdir(pub_dir)
-        with multiprocessing.Pool(processes=min((2, multiprocessing.cpu_count()))) as pool:
-            files_zip = zip(public_files, repeat(pub_dir), repeat(mode), repeat(s3_args)) 
-            pool.starmap(upload_public_file, files_zip) 
-        
         # reset staging tables
         db.execute_sql_file('create_tables_staging.sql')
         # reset metadata table (todo rework on oca_metadata table is parsed)
@@ -303,15 +302,30 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args):
                CREATE INDEX ON oca_metadata (indexnumberid);
 
         """) 
+
+        # # export staging tables, upload to s3, and then rds
+        staging_tables = [t + '_staging' for t in OCA_TABLES] + ['oca_metadata']
+        staging_tables.remove('oca_metadata_staging')
+        for t in staging_tables:
+            csv_filepath = os.path.join(pub_dir, f"{t}.csv")
+            staging_db.export_csv(t, csv_filepath)
+        public_files = os.listdir(pub_dir)
+        with multiprocessing.Pool(processes=min((2, multiprocessing.cpu_count()))) as pool:
+            files_zip = zip(public_files, repeat(pub_dir), repeat(mode), repeat(s3_args)) 
+            pool.starmap(upload_public_file, files_zip) 
+        
         for t in staging_tables:
             print('-', f"{t} table to db")
-            db.sql(f"""
-                SELECT aws_s3.table_import_from_s3(
-                '{t + '_staging'}', '', '(FORMAT CSV, HEADER)',
-                aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/{t}.csv', 'us-east-1'),
-                aws_commons.create_aws_credentials('{s3_args["aws_id"]}', '{s3_args["aws_key"]}', '')
-            );
-            """)
+            # only upload if csv has rows
+            csv_filepath = os.path.join(pub_dir, f"{t}.csv")
+            if len(pd.read_csv(csv_filepath)): # todo - rewrite not to use pandas (csv? or just read file lines using unix)
+                db.sql(f"""
+                    SELECT aws_s3.table_import_from_s3(
+                    '{t}', '', '(FORMAT CSV, HEADER)',
+                    aws_commons.create_s3_uri('{s3_args["aws_bucket_name"]}', 'public/{t}.csv', 'us-east-1'),
+                    aws_commons.create_aws_credentials('{s3_args["aws_id"]}', '{s3_args["aws_key"]}', '')
+                );
+                """)
 
         print('\n   - Updating appearance outcomes...')
         db.execute_sql_file('update_appearance_outcomes.sql')

--- a/lib/sftp.py
+++ b/lib/sftp.py
@@ -1,6 +1,7 @@
 import pysftp
 import shutil
 import os
+import subprocess
 import re
 
 class Sftp:
@@ -8,9 +9,15 @@ class Sftp:
 
     def __init__(self, host, user, pswd, dir):
         # Authorize SSH Host for SFTP connection
-        os.system("ssh-keyscan -t dsa {host} >> ~/.ssh/known_hosts")
+        known_hosts_path = os.path.expanduser('~/.ssh/known_hosts')
+        os.makedirs(os.path.dirname(known_hosts_path), exist_ok=True)
+        try:
+            subprocess.run(['ssh-keyscan', '-H', host], stdout=open(known_hosts_path, 'a'), check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Error running ssh-keyscan: {e}")
+        cnopts = pysftp.CnOpts(knownhosts=known_hosts_path)
 
-        self.sftp = pysftp.Connection(host=host, username=user, password=pswd)
+        self.sftp = pysftp.Connection(host=host, username=user, password=pswd, cnopts=cnopts)
         self.dir = dir
 
 

--- a/lib/sql/create_pluto_table.sql
+++ b/lib/sql/create_pluto_table.sql
@@ -1,5 +1,9 @@
 -- schema for 23v1.2
-CREATE TABLE pluto (
+DROP view IF EXISTS oca_addresses_with_bbl cascade;
+DROP view IF EXISTS oca_addresses_with_ct cascade;
+
+DROP TABLE IF EXISTS pluto;
+CREATE TABLE IF NOT EXISTS pluto(
 	borough varchar(2) NULL,
 	block int4 NULL,
 	lot int4 NULL,
@@ -93,6 +97,3 @@ CREATE TABLE pluto (
 	longitude float8 NULL,
 	notes text NULL
 );
-
-drop view if exists oca_addresses_with_bbl cascade;
-drop view if exists oca_addresses_with_ct cascade;

--- a/lib/sql/create_tables_staging.sql
+++ b/lib/sql/create_tables_staging.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS oca_index_staging;
+DROP TABLE IF EXISTS oca_index_staging CASCADE;
 CREATE TABLE IF NOT EXISTS oca_index_staging (
 	LIKE oca_index 
 	INCLUDING DEFAULTS
@@ -12,11 +12,35 @@ CREATE TABLE IF NOT EXISTS oca_causes_staging (
 	INCLUDING INDEXES
 );
 
+-- hardcode oca_addresses since some versions of this table can have geom
 DROP TABLE IF EXISTS oca_addresses_staging;
 CREATE TABLE IF NOT EXISTS oca_addresses_staging (
-	LIKE oca_addresses 
-	INCLUDING DEFAULTS
-	INCLUDING INDEXES
+  indexnumberid text,
+  street1 text,
+  street2 text,
+  city text,
+  state text,
+  postalcode text,
+  status text,
+  house_number text,
+  street_name text,
+  borough_code text,
+  place_name text,
+  sname text,
+  hnum text,
+  boro text,
+  lat real,
+  bin text,
+  bbl text,
+  cd text,
+  ct text,
+  council text,
+  grc text,
+  grc2 text,
+  msg text,
+  msg2 text,
+  lon real,
+  zip_code text
 );
 
 DROP TABLE IF EXISTS oca_parties_staging;
@@ -75,13 +99,6 @@ CREATE TABLE IF NOT EXISTS oca_judgments_staging (
 DROP TABLE IF EXISTS oca_warrants_staging;
 CREATE TABLE IF NOT EXISTS oca_warrants_staging (
 	LIKE oca_warrants 
-	INCLUDING DEFAULTS
-	INCLUDING INDEXES
-);
-
-DROP TABLE IF EXISTS oca_metadata_staging;
-CREATE TABLE IF NOT EXISTS oca_metadata_staging (
-	LIKE oca_metadata
 	INCLUDING DEFAULTS
 	INCLUDING INDEXES
 );

--- a/lib/sql/create_tables_staging.sql
+++ b/lib/sql/create_tables_staging.sql
@@ -79,7 +79,6 @@ CREATE TABLE IF NOT EXISTS oca_warrants_staging (
 	INCLUDING INDEXES
 );
 
-
 DROP TABLE IF EXISTS oca_metadata_staging;
 CREATE TABLE IF NOT EXISTS oca_metadata_staging (
 	LIKE oca_metadata

--- a/lib/sql/create_tables_staging.sql
+++ b/lib/sql/create_tables_staging.sql
@@ -78,3 +78,11 @@ CREATE TABLE IF NOT EXISTS oca_warrants_staging (
 	INCLUDING DEFAULTS
 	INCLUDING INDEXES
 );
+
+
+DROP TABLE IF EXISTS oca_metadata_staging;
+CREATE TABLE IF NOT EXISTS oca_metadata_staging (
+	LIKE oca_metadata
+	INCLUDING DEFAULTS
+	INCLUDING INDEXES
+);

--- a/lib/sql/update_appearance_outcomes.sql
+++ b/lib/sql/update_appearance_outcomes.sql
@@ -1,4 +1,4 @@
--- In the "appearances" nodes they have further nested info aobut the outcomes
+-- In the "appearances" nodes they have further nested info about the outcomes
 -- of those appearances. There are no unique identifers to be able to link
 -- these elements in the original data, so we parse the outcomes as a json
 -- column in the appearances column and use postgres to generate an ID column


### PR DESCRIPTION
This version re-adds the local postgres instance (**staging_db**) to be used for the staging table/ parsing xml steps since parsing the XML directly to the remotedb takes A LONG TIME. (7 minutes vs ~5 hours)

- Creates oca tables (not used), and oca stagging tables on the **staging_db**
- Imports the `oca_metadata` table from s3/rds to the local **staging_db** (see notes below)
- Parses the XML
- Exports the oca stagging tables to csvs, uploads them to s3, then imports the tables into rds to continue the rest of the script.

Also re-adds 

- `ALTER TABLE oca_index DISABLE TRIGGER ALL` as `SET session_replication_role = replica;` to avoid lock ups with DELETE FROM command stalling.

**Notes**

- Currently the `update_metadata` function is dependent on having a local version of the oca_metadata. We want to create a sql query that will merge the oca_metadata_staging version into the remote db, instead of having to create local version of the file then having to do the steps in exporting from s3, importing to the **staging_db**, running parse_case and update_metadata, then exporting the table to a csv, upload to s3, and importing to the rds.

- Another work around to the slow write speeds to the RDS would be to batch write the xml request. Probably will still take an hour.