### PR TITLE
fix pluto join for possible trailing ".000"

### DIFF
--- a/lib/sql/create_addresses_views.sql
+++ b/lib/sql/create_addresses_views.sql
@@ -27,8 +27,7 @@ CREATE OR REPLACE VIEW public.oca_addresses_with_bbl AS
 			ELSE NULL
 		END AS bbl
 	FROM oca_addresses o
-	LEFT JOIN 
-		pluto USING(bbl);
+	LEFT JOIN pluto p ON LEFT(p.bbl, 10) = o.bbl;
 
 -- update oca_addresses with geom field
 ALTER TABLE oca_addresses 


### PR DESCRIPTION
In creating the VIEW for `oca_addresses_with_bbl` (which we then export to csv in the S3 for use by JustFix/ANHD in WOW/DAP) we are first joining with pluto on bbl for `unitsres` to censor bbls from small buildings. It appears that when pluto was getting loaded it had bbl formatted with `.00000000` trailing all the values. So this just fixes that join. Then later we can follow up with a fix for the pluto import. 

I've already updated the view on the db, and uploaded the csv to s3, and it all is working - so this can just be for the next update run.