### PR TITLE
specify s3 server side encryption

### DIFF
--- a/lib/s3.py
+++ b/lib/s3.py
@@ -55,7 +55,8 @@ def put_object(s3_client, dest_bucket_name, dest_object_name, src_data, content_
 		'Bucket': dest_bucket_name, 
 		'Key': dest_object_name, 
 		'Body': object_data,
-		'ContentType': content_type
+		'ContentType': content_type,
+		'ServerSideEncryption': 'AES256' # Amazon S3 managed keys (SSE-S3)
 	}
 
 	if cache_control != '':


### PR DESCRIPTION
At times the server side encryption type for public csv files in the S3 bucket changed when updloading new version from the default Amazon S3 managed keys (SSE-S3) (` 'AES256'`) to AWS KMS managed key, and so users would get an error when trying to download those public files (#15)

This PR specifies the encryption time on the `put_object()` to hopefully prevent this