### PR TITLE
handle cases marked for deletion

### DIFF
--- a/docs/operations/weekly-etl-scheduling.md
+++ b/docs/operations/weekly-etl-scheduling.md
@@ -8,6 +8,8 @@ python oca_update.py
 
 Historical RDS rows that still lack coordinates are handled separately by `oca_geocode_backfill.py` (not scheduled with weekly ETL). See [RDS geocode backfill](#rds-geocode-backfill-on-demand) below.
 
+Cases marked deleted in OCA XML are tombstoned in `oca_metadata.deletedate` and purged from `oca_index` (and child tables) during weekly promotion. Historical orphans (tombstone without purge) are cleaned by `oca_deletion_backfill.py` — see [RDS deletion backfill](#rds-deletion-backfill-on-demand).
+
 Use Docker (or the published image `justfixnyc/oca:latest`) with credentials supplied via environment variables or a secret store. See [Runtime controls](#runtime-controls) and the root [README](../../README.md).
 
 ## Runtime controls
@@ -51,6 +53,28 @@ Same secrets as weekly ETL (`DATABASE_URL`, `DB_SCHEMA`, AWS if needed for manif
 - Selects only ungeocoded rows (`select_addresses_needing_geocode.sql`).
 - Records manifest `mode='geocode_backfill'` with step `geocode_refresh` only.
 - **Does not** run `create_addresses_views.sql` or publish public CSVs. Re-run publish (or a full `oca_update.py` publish path) if S3 must reflect backfilled coordinates.
+
+## RDS deletion backfill (on-demand)
+
+Use after deploying tombstone-aware promotion, or when validation shows case rows still present for deleted metadata. **Not** wired into weekly ETL.
+
+```bash
+docker compose run --rm app python oca_deletion_backfill.py
+```
+
+Same secrets as weekly ETL (`DATABASE_URL`, `DB_SCHEMA`). Records manifest `mode='deletion_backfill'` with step `deletion_backfill`.
+
+- Deletes from `oca_index` only (child tables CASCADE); **`oca_metadata` rows are kept** (`deletedate` preserved).
+- **Does not** publish public CSVs. Re-run weekly publish if S3 must drop deleted cases from snapshots.
+
+**Validation** (expect `0` after a successful backfill):
+
+```sql
+SELECT COUNT(*)::bigint
+FROM oca_index i
+INNER JOIN oca_metadata m ON m.indexnumberid = i.indexnumberid
+WHERE m.deletedate IS NOT NULL;
+```
 
 ## 1. Local Docker + cron (weekly)
 

--- a/lib/etl_promotion.py
+++ b/lib/etl_promotion.py
@@ -5,6 +5,7 @@ from .etl_constants import OCA_TABLES
 
 PROMOTION_SQL_FILE = 'promote_staging_to_main.sql'
 PROMOTION_INDEX_SQL_FILE = 'ensure_promotion_indexes.sql'
+PURGE_TOMBSTONED_CASES_SQL_FILE = 'purge_tombstoned_cases.sql'
 
 # Tables promoted via promote_staging_to_main.sql (oca_metadata merged in-SQL).
 PROMOTED_TABLES = [t for t in OCA_TABLES if t != 'oca_metadata']

--- a/lib/etl_stages.py
+++ b/lib/etl_stages.py
@@ -19,7 +19,10 @@ from .etl_helpers import (
     s3_key,
     upload_public_file,
 )
-from .etl_promotion import promote_staging_to_main
+from .etl_promotion import (
+    PURGE_TOMBSTONED_CASES_SQL_FILE,
+    promote_staging_to_main,
+)
 from .etl_publish import (
     ADDRESS_VIEW_EXPORTS,
     export_table_to_s3,
@@ -299,6 +302,34 @@ def publish_core_tables(db, s3_args, s3_prefix):
             export_table_to_s3(db, t, s3_filename, s3_args, s3_prefix)
         )
     return published_keys
+
+
+def count_tombstone_orphans(db):
+    """Cases with oca_metadata.deletedate still present in oca_index."""
+    row = db.sql_fetch_one("""
+        SELECT COUNT(*)::bigint
+        FROM oca_index i
+        INNER JOIN oca_metadata m ON m.indexnumberid = i.indexnumberid
+        WHERE m.deletedate IS NOT NULL
+    """)
+    return int(row[0]) if row else 0
+
+
+def purge_tombstoned_cases(manifest, db):
+    """Delete oca_index rows (and children via CASCADE) for metadata tombstones."""
+    manifest.upsert_step('deletion_backfill', 'running')
+    orphan_count_before = count_tombstone_orphans(db)
+    db.execute_sql_file(PURGE_TOMBSTONED_CASES_SQL_FILE)
+    orphan_count_after = count_tombstone_orphans(db)
+    manifest.upsert_step(
+        'deletion_backfill',
+        'completed',
+        details={
+            'orphan_count_before': orphan_count_before,
+            'orphan_count_after': orphan_count_after,
+        },
+    )
+    return orphan_count_before, orphan_count_after
 
 
 def geocode_addresses(manifest, db, pub_dir, geocode_workers, census_batch_chunk_size):

--- a/lib/sql/promote_staging_to_main.sql
+++ b/lib/sql/promote_staging_to_main.sql
@@ -1,40 +1,56 @@
 -- Atomic staging -> main promotion for one import batch.
--- Case scope: all indexnumberid values present in oca_index_staging.
--- oca_index uses UPSERT; child tables use scoped DELETE + INSERT; metadata merged last.
+-- Tombstoned cases (oca_metadata / oca_metadata_staging deletedate) are purged from
+-- oca_index (children CASCADE) and excluded from staging upserts.
+-- oca_index uses UPSERT for active staging cases; metadata merged before staging drops.
 
 SET session_replication_role = replica;
 
--- Child tables keyed by indexnumberid (full per-case row replace for the batch).
+CREATE TEMP TABLE tombstoned_ids ON COMMIT DROP AS
+SELECT indexnumberid FROM oca_metadata WHERE deletedate IS NOT NULL
+UNION
+SELECT indexnumberid FROM oca_metadata_staging WHERE deletedate IS NOT NULL;
+
+DELETE FROM oca_index
+WHERE indexnumberid IN (SELECT indexnumberid FROM tombstoned_ids);
+
+CREATE TEMP TABLE promotion_active_staging_ids ON COMMIT DROP AS
+SELECT s.indexnumberid
+FROM oca_index_staging s
+WHERE NOT EXISTS (
+    SELECT 1 FROM tombstoned_ids t WHERE t.indexnumberid = s.indexnumberid
+);
+
+-- Child tables keyed by indexnumberid (full per-case row replace for active staging cases).
 DELETE FROM oca_appearance_outcomes
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 DELETE FROM oca_appearances
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 DELETE FROM oca_warrants
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 DELETE FROM oca_judgments
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 DELETE FROM oca_decisions
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 DELETE FROM oca_motions
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 DELETE FROM oca_events
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 DELETE FROM oca_parties
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 DELETE FROM oca_causes
-WHERE indexnumberid IN (SELECT indexnumberid FROM oca_index_staging);
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 -- Addresses: natural-line key aligned with incremental geocode.
 DELETE FROM oca_addresses m
-WHERE m.indexnumberid IN (SELECT indexnumberid FROM oca_index_staging)
+WHERE m.indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids)
 AND NOT EXISTS (
     SELECT 1
     FROM oca_addresses_staging s
@@ -48,7 +64,8 @@ AND NOT EXISTS (
 
 DELETE FROM oca_addresses m
 USING oca_addresses_staging s
-WHERE m.indexnumberid = s.indexnumberid
+WHERE m.indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids)
+  AND m.indexnumberid = s.indexnumberid
   AND m.street1 IS NOT DISTINCT FROM s.street1
   AND m.street2 IS NOT DISTINCT FROM s.street2
   AND m.city IS NOT DISTINCT FROM s.city
@@ -65,6 +82,7 @@ SELECT
     specialtydesignationtypes, status, disposeddate, disposedreason,
     firstpaper, primaryclaimtotal, dateofjurydemand
 FROM oca_index_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids)
 ON CONFLICT (indexnumberid) DO UPDATE SET
     court = EXCLUDED.court,
     fileddate = EXCLUDED.fileddate,
@@ -78,7 +96,10 @@ ON CONFLICT (indexnumberid) DO UPDATE SET
     primaryclaimtotal = EXCLUDED.primaryclaimtotal,
     dateofjurydemand = EXCLUDED.dateofjurydemand;
 
-INSERT INTO oca_causes SELECT * FROM oca_causes_staging;
+INSERT INTO oca_causes
+SELECT * FROM oca_causes_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
+
 INSERT INTO oca_addresses (
     indexnumberid, street1, street2, city, state, postalcode, status,
     house_number, street_name, borough_code, place_name, sname, hnum, boro,
@@ -88,22 +109,46 @@ SELECT
     indexnumberid, street1, street2, city, state, postalcode, status,
     house_number, street_name, borough_code, place_name, sname, hnum, boro,
     lat, bin, bbl, cd, ct, council, grc, grc2, msg, msg2, lon, zip_code
-FROM oca_addresses_staging;
+FROM oca_addresses_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 UPDATE oca_addresses AS o
 SET geom = ST_SetSRID(ST_Point(o.lon, o.lat), 4326)
-WHERE o.indexnumberid IN (SELECT indexnumberid FROM oca_index_staging)
+WHERE o.indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids)
   AND o.lat IS NOT NULL
   AND o.lon IS NOT NULL;
 
-INSERT INTO oca_parties SELECT * FROM oca_parties_staging;
-INSERT INTO oca_events SELECT * FROM oca_events_staging;
-INSERT INTO oca_appearances SELECT * FROM oca_appearances_staging;
-INSERT INTO oca_appearance_outcomes SELECT * FROM oca_appearance_outcomes_staging;
-INSERT INTO oca_motions SELECT * FROM oca_motions_staging;
-INSERT INTO oca_decisions SELECT * FROM oca_decisions_staging;
-INSERT INTO oca_judgments SELECT * FROM oca_judgments_staging;
-INSERT INTO oca_warrants SELECT * FROM oca_warrants_staging;
+INSERT INTO oca_parties
+SELECT * FROM oca_parties_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
+
+INSERT INTO oca_events
+SELECT * FROM oca_events_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
+
+INSERT INTO oca_appearances
+SELECT * FROM oca_appearances_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
+
+INSERT INTO oca_appearance_outcomes
+SELECT * FROM oca_appearance_outcomes_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
+
+INSERT INTO oca_motions
+SELECT * FROM oca_motions_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
+
+INSERT INTO oca_decisions
+SELECT * FROM oca_decisions_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
+
+INSERT INTO oca_judgments
+SELECT * FROM oca_judgments_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
+
+INSERT INTO oca_warrants
+SELECT * FROM oca_warrants_staging
+WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids);
 
 -- Metadata merge (no nested transaction; must run before staging drops).
 CREATE TABLE oca_metadata_temp AS
@@ -117,6 +162,12 @@ FULL OUTER JOIN oca_metadata_staging oms ON om.indexnumberid = oms.indexnumberid
 
 DROP TABLE oca_metadata;
 ALTER TABLE oca_metadata_temp RENAME TO oca_metadata;
+
+-- Apply tombstones merged this batch (delete-only incr may add new deletedate rows).
+DELETE FROM oca_index
+WHERE indexnumberid IN (
+    SELECT indexnumberid FROM oca_metadata WHERE deletedate IS NOT NULL
+);
 
 DROP TABLE IF EXISTS oca_index_staging CASCADE;
 DROP TABLE IF EXISTS oca_causes_staging CASCADE;

--- a/lib/sql/purge_tombstoned_cases.sql
+++ b/lib/sql/purge_tombstoned_cases.sql
@@ -1,0 +1,9 @@
+-- Remove production case data for tombstoned indexnumberids (oca_metadata.deletedate).
+-- Child rows cascade from oca_index; oca_metadata rows are preserved.
+
+DELETE FROM oca_index
+WHERE indexnumberid IN (
+    SELECT m.indexnumberid
+    FROM oca_metadata m
+    WHERE m.deletedate IS NOT NULL
+);

--- a/oca_deletion_backfill.py
+++ b/oca_deletion_backfill.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+
+import dotenv
+
+from lib.database import Database
+from lib.etl_run_manifest import EtlRunManifest
+from lib.etl_stages import purge_tombstoned_cases
+
+dotenv.load_dotenv()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            'Remove oca_index rows (and child tables via CASCADE) for cases '
+            'with oca_metadata.deletedate set'
+        ),
+    )
+    parser.add_argument(
+        '--db-schema',
+        default=os.environ.get('DB_SCHEMA', ''),
+        help='Database schema search_path target',
+    )
+    return parser.parse_args()
+
+
+def run_deletion_backfill(db_args, runtime_args=None):
+    """Purge production case data for metadata tombstones."""
+    runtime_args = runtime_args or {}
+    db_schema = runtime_args.get('db_schema') or db_args.get('schema') or 'public'
+
+    db = Database(**db_args)
+    manifest = EtlRunManifest(
+        db=db,
+        schema_name=db_schema,
+        s3_prefix='',
+        mode='deletion_backfill',
+        reprocess_glob='',
+        force_reprocess=False,
+    )
+    manifest.setup_tables()
+    manifest.create_run()
+
+    try:
+        db.ensure_connection()
+        orphan_before, orphan_after = purge_tombstoned_cases(manifest, db)
+        manifest.mark_run_completed(0, 0, 0)
+        print(
+            f'Deletion backfill complete; '
+            f'orphans before={orphan_before}, after={orphan_after}'
+        )
+        return orphan_before, orphan_after
+    except Exception as exc:
+        manifest.mark_run_failed(exc)
+        raise
+
+
+def main():
+    args = parse_args()
+    db_args = {
+        'db_url': os.environ.get('DATABASE_URL', ''),
+        'schema': args.db_schema,
+    }
+    runtime_args = {'db_schema': args.db_schema}
+    run_deletion_backfill(db_args, runtime_args)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_deletion_backfill.py
+++ b/tests/test_deletion_backfill.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest import mock
+
+from lib.etl_stages import count_tombstone_orphans, purge_tombstoned_cases
+
+
+class TombstoneOrphanCountTests(unittest.TestCase):
+    def test_count_tombstone_orphans(self):
+        db = mock.Mock()
+        db.sql_fetch_one.return_value = (3,)
+        self.assertEqual(count_tombstone_orphans(db), 3)
+        self.assertIn('oca_metadata', db.sql_fetch_one.call_args[0][0])
+        self.assertIn('deletedate IS NOT NULL', db.sql_fetch_one.call_args[0][0])
+
+
+class PurgeTombstonedCasesTests(unittest.TestCase):
+    def test_purge_runs_sql_and_records_manifest(self):
+        db = mock.Mock()
+        db.sql_fetch_one.side_effect = [(5,), (0,)]
+        manifest = mock.Mock()
+
+        before, after = purge_tombstoned_cases(manifest, db)
+
+        self.assertEqual((before, after), (5, 0))
+        db.execute_sql_file.assert_called_once_with('purge_tombstoned_cases.sql')
+        manifest.upsert_step.assert_any_call('deletion_backfill', 'running')
+        manifest.upsert_step.assert_any_call(
+            'deletion_backfill',
+            'completed',
+            details={'orphan_count_before': 5, 'orphan_count_after': 0},
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -7,6 +7,7 @@ from lib.etl_constants import OCA_TABLES
 from lib.etl_promotion import (
     ADDRESS_NATURAL_KEY_COLUMNS,
     PROMOTION_SQL_FILE,
+    PURGE_TOMBSTONED_CASES_SQL_FILE,
     promote_staging_to_main,
     promotion_counts_checksum,
     promotion_table_counts,
@@ -114,9 +115,27 @@ class PromoteStagingSqlContractTests(unittest.TestCase):
         self.assertIn('SET session_replication_role = replica', self.sql)
         self.assertIn('SET session_replication_role = default', self.sql)
 
-    def test_oca_index_upsert_not_delete(self):
+    def test_oca_index_upsert_with_tombstone_purge(self):
         self.assertIn('ON CONFLICT (indexnumberid) DO UPDATE', self.sql)
-        self.assertNotRegex(self.sql, r'DELETE FROM oca_index\b')
+        self.assertRegex(self.sql, r'DELETE FROM oca_index\b')
+        self.assertGreaterEqual(self.sql.count('DELETE FROM oca_index'), 2)
+
+    def test_tombstone_temp_tables_and_filtered_staging(self):
+        self.assertIn('CREATE TEMP TABLE tombstoned_ids', self.sql)
+        self.assertIn('CREATE TEMP TABLE promotion_active_staging_ids', self.sql)
+        self.assertIn('oca_metadata_staging WHERE deletedate IS NOT NULL', self.sql)
+        self.assertIn(
+            'FROM oca_index_staging\nWHERE indexnumberid IN '
+            '(SELECT indexnumberid FROM promotion_active_staging_ids)',
+            self.sql,
+        )
+
+    def test_child_inserts_exclude_tombstones(self):
+        self.assertIn(
+            'FROM oca_causes_staging\n'
+            'WHERE indexnumberid IN (SELECT indexnumberid FROM promotion_active_staging_ids)',
+            self.sql,
+        )
 
     def test_addresses_use_natural_key_delete(self):
         for col in ADDRESS_NATURAL_KEY_COLUMNS:
@@ -132,6 +151,14 @@ class PromoteStagingSqlContractTests(unittest.TestCase):
     def test_all_staging_tables_dropped(self):
         for table in OCA_TABLES:
             self.assertIn(f'DROP TABLE IF EXISTS {table}_staging', self.sql)
+
+
+class PurgeTombstonedCasesSqlContractTests(unittest.TestCase):
+    def test_purge_deletes_index_not_metadata(self):
+        sql = (SQL_DIR / PURGE_TOMBSTONED_CASES_SQL_FILE).read_text(encoding='utf-8')
+        self.assertRegex(sql, r'DELETE FROM oca_index\b')
+        self.assertIn('oca_metadata', sql)
+        self.assertNotRegex(sql, r'DELETE FROM oca_metadata\b')
 
 
 class DatabaseTransactionTests(unittest.TestCase):


### PR DESCRIPTION
In the OCA XML files some cases are marked for permanent deletion and this wasn't handled correctly if files are ever reprocessed out of order since previously deleted cases could be restored. This PR adds extra protection against that issue by explicitly deleting cases marked for deletion (which we already record in `oca_metadata.deletedate`) before promoting staging data to main, and adds a one-off backfill script to purge all cases.