### PR TITLE
Handle failed parse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,9 @@ REPROCESS_GLOB=
 # When true, replay REPROCESS_GLOB matches even if already completed in etl_files manifest
 FORCE_REPROCESS=false
 
+# When true, fail parse_xml and abort before export/promote if any case-level parse errors occur
+PARSE_FAIL_FAST=false
+
 # Geocoding and CSV tuning (optional; safe defaults preserve current behavior)
 GEOCODE_WORKERS=
 CENSUS_BATCH_CHUNK_SIZE=2500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     user: 'root'
     volumes:
       - .:/app
+      # Keep Linux .venv out of the host bind mount (macOS .venv breaks imports in-container).
+      - app_venv:/app/.venv
     environment:
       DATABASE_URL: ${DATABASE_URL}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
@@ -23,3 +25,6 @@ services:
     # ports:
     #   - 8888:8888
     tty: true
+
+volumes:
+  app_venv:

--- a/docs/operations/weekly-etl-scheduling.md
+++ b/docs/operations/weekly-etl-scheduling.md
@@ -25,6 +25,7 @@ Use Docker (or the published image `justfixnyc/oca:latest`) with credentials sup
 | `S3_PREFIX` | Key prefix for `private/` and `public/` | empty → bucket root |
 | `REPROCESS_GLOB` | Replay zip files from S3 `private/` | empty |
 | `FORCE_REPROCESS` | Replay manifest-completed files | `false` |
+| `PARSE_FAIL_FAST` | Fail `parse_xml` and abort before export/promote when any zip has case-level parse failures | `false` |
 | `GEOCODE_WORKERS` | Geosupport pool size | CPU count |
 | `CENSUS_BATCH_CHUNK_SIZE` | Census batch chunk | `2500` |
 | `CSV_ROW_CHECK_CHUNK_SIZE` | Staging CSV preprocess chunk | `1000` |
@@ -32,6 +33,8 @@ Use Docker (or the published image `justfixnyc/oca:latest`) with credentials sup
 Refactor and E2E runs must set `S3_PREFIX=refactor/` (or another isolated prefix) so reads/writes stay out of production public paths.
 
 Memory target: **≤ 2 GiB** per job. Tune `GEOCODE_WORKERS` down (e.g. `2`) if geocoding approaches the limit.
+
+**Parse failures (default lenient):** With `PARSE_FAIL_FAST=false`, weekly runs still promote and publish; zips with any `cases_failed` in manifest `etl_files.details` do **not** reach `status = 'completed'` (requires **`cases_failed = 0`**) and are omitted from `completed_reprocess_files` on later `REPROCESS_GLOB` runs (no `FORCE_REPROCESS` needed to retry them). Set `PARSE_FAIL_FAST=true` to stop the run before export/promote.
 
 ## Publish behavior
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -35,7 +35,7 @@ Each weekly run is orchestrated sequentially in `oca_etl()`. There is **no** pos
 |-------|--------|--------------|
 | Select files | `etl_file_selection.py`, `etl_stages.select_input_files` | Picks new SFTP zips and/or S3 private replays (`REPROCESS_GLOB`); skips manifest-completed files unless `FORCE_REPROCESS=true`. |
 | Download | `etl_stages.download_selected_files` | New files from SFTP; replay files from S3 private backup. |
-| Parse | `parsers.py`, `duckdb_database.py` | Streaming XML parse into local DuckDB (`staging.duckdb`); batched writes via `parse_write_buffer.py`. Address rows have no lat/lon until CSV geocode. |
+| Parse | `parsers.py`, `duckdb_database.py`, `parse_manifest.py` | Streaming XML parse into local DuckDB (`staging.duckdb`); batched writes via `parse_write_buffer.py` with per-case windows (`begin_case` / `discard_case` on error—no partial case rows). Per-zip `cases_seen` / `cases_parsed_ok` / `cases_failed` (+ capped `error_samples`) on `etl_files.details`. Default lenient: promote/publish still run; `etl_files.status = 'completed'` only when **`cases_failed = 0`** after promote. `PARSE_FAIL_FAST` aborts before export/promote. Address rows have no lat/lon until CSV geocode. |
 | Export staging | `etl_stages.export_staging_csvs` | DuckDB `COPY` with Postgres-compatible transforms; manifest step `export_staging`. No S3 upload yet. |
 | Geocode staging | `etl_geocode.geocode_staging_addresses_csv`, `etl_stages.geocode_staging_csvs` | Geocode **every** row in `oca_addresses_staging.csv`; write `oca_addresses_staging_geocoded.csv`, copy over staging CSV; manifest step `geocode_staging`. |
 | Upload staging | `etl_stages.upload_staging_csvs`, `etl_publish.list_staging_csvs_in_dir` | Upload only whitelisted `{table}_staging.csv` files (from `OCA_TABLES`); ignores geocoder temps and other junk; manifest step `upload_staging`. |
@@ -104,7 +104,7 @@ Legacy/manual only: `reset_addresses_table.sql`, `update_metadata.sql`.
 
 - **Manifest** — weekly runs record `export_staging`, `geocode_staging`, `upload_staging`, `promote_staging`, `publish_public`, `normalize_s3_encryption`, `upload_private`. Backfill runs record only `geocode_refresh`.
 - **Connection resilience** — TCP keepalives and `ensure_connection()` before promote and before publish.
-- **Reprocess** — `REPROCESS_GLOB` selects S3 private backups; manifest skips completed files unless `FORCE_REPROCESS=true`.
+- **Reprocess** — `REPROCESS_GLOB` selects S3 private backups; manifest skips files in `completed_reprocess_files` (promoted with `cases_failed = 0`) unless `FORCE_REPROCESS=true`. Zips with prior case-level parse failures stay eligible for reprocess without force.
 - **Schema isolation** — `DB_SCHEMA` + `S3_PREFIX` for refactor/E2E without touching production paths.
 - **Weekly geocode** — all staging CSV address rows (re-geocodes rows that already have lat/lon in the file).
 - **Backfill geocode** — only `lat IS NULL` with a house number; upsert matches on address line columns, not `indexnumberid` alone.

--- a/lib/etl.py
+++ b/lib/etl.py
@@ -29,6 +29,7 @@ from .etl_promotion import (
     promotion_table_counts,
 )
 from .etl_run_manifest import EtlRunManifest, completed_reprocess_files, manifest_step
+from .parse_manifest import ParseFailFastError, file_names_needing_reprocess
 from .etl_stages import (
     FileSelection,
     download_selected_files,
@@ -83,6 +84,7 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args, runtime_args=None
     geocode_workers = runtime_args.get('geocode_workers') or multiprocessing.cpu_count()
     census_batch_chunk_size = runtime_args.get('census_batch_chunk_size') or 2500
     csv_row_check_chunk_size = runtime_args.get('csv_row_check_chunk_size') or 1000
+    parse_fail_fast = bool(runtime_args.get('parse_fail_fast'))
 
     db = Database(**db_args)
     manifest = EtlRunManifest(
@@ -114,7 +116,7 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args, runtime_args=None
             return True
 
         download_selected_files(manifest, sftp, s3, priv_dir, s3_prefix, selection)
-        parse_xml_to_staging(manifest, staging_db, priv_dir)
+        parse_xml_to_staging(manifest, staging_db, priv_dir, parse_fail_fast=parse_fail_fast)
         export_staging_csvs(
             manifest, staging_db, pub_dir,
             csv_preprocess_chunk_size=csv_row_check_chunk_size,
@@ -140,14 +142,17 @@ def oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args, runtime_args=None
         normalize_public_s3_encryption(manifest, s3, published_keys)
         upload_private_source_files(manifest, s3, priv_dir, s3_prefix)
 
+        files_needing_reprocess = file_names_needing_reprocess(manifest.file_details_by_name)
+        processed_count = len(selection.selected_zip_files) - len(files_needing_reprocess)
         manifest.mark_run_completed(
             len(selection.selected_zip_files),
-            len(selection.selected_zip_files),
-            len(selection.skipped_reprocess_files)
+            processed_count,
+            len(selection.skipped_reprocess_files),
+            files_needing_reprocess=files_needing_reprocess or None,
         )
         return True
     except Exception as exc:
-        if selection and selection.selected_zip_files:
+        if selection and selection.selected_zip_files and not isinstance(exc, ParseFailFastError):
             for selected_name in selection.selected_zip_files:
                 source = 'sftp' if selected_name in selection.new_file_set else 's3_private'
                 manifest.upsert_file(selected_name, source=source, status='failed', stage='run', error=exc)

--- a/lib/etl_run_manifest.py
+++ b/lib/etl_run_manifest.py
@@ -23,6 +23,7 @@ class EtlRunManifest:
         self.reprocess_glob = reprocess_glob or ''
         self.force_reprocess = force_reprocess
         self.run_id = str(uuid.uuid4())
+        self.file_details_by_name = {}
 
     def setup_tables(self):
         self.db.execute_sql_file('create_etl_manifest_tables.sql')
@@ -45,7 +46,21 @@ class EtlRunManifest:
             )
         """)
 
-    def mark_run_completed(self, selected_count, processed_count, skipped_count):
+    def mark_run_completed(
+        self,
+        selected_count,
+        processed_count,
+        skipped_count,
+        files_needing_reprocess=None,
+    ):
+        metadata_patch = {}
+        if files_needing_reprocess:
+            metadata_patch['files_needing_reprocess'] = list(files_needing_reprocess)
+        metadata_sql = (
+            f", metadata = metadata || {self._json_literal(metadata_patch)}"
+            if metadata_patch
+            else ""
+        )
         self.db.sql(f"""
             UPDATE etl_runs
             SET status = 'completed',
@@ -53,6 +68,7 @@ class EtlRunManifest:
                 selected_file_count = {selected_count},
                 processed_file_count = {processed_count},
                 skipped_file_count = {skipped_count}
+                {metadata_sql}
             WHERE run_id = {self._literal(self.run_id)}
         """)
 
@@ -69,6 +85,8 @@ class EtlRunManifest:
         """)
 
     def upsert_file(self, file_name, source, status, stage=None, details=None, error=None):
+        if details is not None:
+            self.file_details_by_name[file_name] = dict(details)
         stage_value = "NULL" if stage is None else self._literal(stage)
         details_value = self._json_literal(details or {})
         error_message = "NULL" if error is None else self._literal(str(error))
@@ -139,6 +157,7 @@ def completed_reprocess_files(db, reprocess_files):
         JOIN etl_runs er ON er.run_id = ef.run_id
         WHERE ef.status = 'completed'
           AND er.status = 'completed'
+          AND COALESCE((ef.details->>'cases_failed')::int, 0) = 0
           AND ef.file_name IN ({quoted_files})
     """)
     return {row[0] for row in rows}

--- a/lib/etl_stages.py
+++ b/lib/etl_stages.py
@@ -36,6 +36,10 @@ from .etl_geocode import (
     geocode_staging_addresses_csv,
     upsert_geocoded_addresses,
 )
+from .parse_manifest import (
+    build_parse_xml_step_details,
+    upsert_parsed_etl_file,
+)
 from .parsers import oca_tag, parse_file
 
 
@@ -138,6 +142,8 @@ def parse_xml_to_staging(manifest, staging_db, priv_dir, parse_num_threads=8):
     manifest.upsert_step('parse_xml', 'running')
     staging_db.execute_sql_file('lib/sql/create_tables_staging_duckdb.sql')
     print('Processing files:')
+    total_cases_failed = 0
+    files_with_failures = 0
     for zip_file in local_zip_files:
         file_name = os.path.basename(zip_file)
         manifest.upsert_file(file_name, source='local', status='processing', stage='parse')
@@ -148,17 +154,22 @@ def parse_xml_to_staging(manifest, staging_db, priv_dir, parse_num_threads=8):
                     extract_date = elem.text
                     break
         with zipfile.ZipFile(zip_file, 'r').open(DATA_FILENAME) as xml_file:
-            parse_file(
+            parse_result = parse_file(
                 xml_file,
                 staging_db,
                 extract_date,
                 num_threads=parse_num_threads,
+                file_name=file_name,
             )
-        manifest.upsert_file(
-            file_name, source='local', status='parsed', stage='parse',
-            details={'extract_date': extract_date}
-        )
-    manifest.upsert_step('parse_xml', 'completed')
+        failed = upsert_parsed_etl_file(manifest, file_name, parse_result, extract_date)
+        total_cases_failed += failed
+        if failed > 0:
+            files_with_failures += 1
+    manifest.upsert_step(
+        'parse_xml',
+        'completed',
+        details=build_parse_xml_step_details(total_cases_failed, files_with_failures),
+    )
 
 
 def export_staging_to_csv(

--- a/lib/etl_stages.py
+++ b/lib/etl_stages.py
@@ -22,6 +22,8 @@ from .etl_helpers import (
 from .etl_promotion import (
     PURGE_TOMBSTONED_CASES_SQL_FILE,
     promote_staging_to_main,
+    promotion_counts_checksum,
+    promotion_table_counts,
 )
 from .etl_publish import (
     ADDRESS_VIEW_EXPORTS,
@@ -291,13 +293,26 @@ def import_and_promote_staging(manifest, db, pub_dir, s3_args, s3_prefix, select
 
     db.execute_sql_file('normalize_staging_after_import.sql')
     db.execute_sql_file('update_appearance_outcomes.sql')
+    counts_before = promotion_table_counts(db)
+    checksum_before = promotion_counts_checksum(counts_before)
     print('\t...Promoting staging tables to main (single transaction)')
     promote_staging_to_main(db)
+    counts_after = promotion_table_counts(db)
+    checksum_after = promotion_counts_checksum(counts_after)
     for selected_name in selection.selected_zip_files:
         source = 'sftp' if selected_name in selection.new_file_set else 's3_private'
         parse_details = manifest.file_details_by_name.get(selected_name, {})
         upsert_promoted_etl_file(manifest, selected_name, source, parse_details)
-    manifest.upsert_step('promote_staging', 'completed')
+    manifest.upsert_step(
+        'promote_staging',
+        'completed',
+        details={
+            'counts_before': counts_before,
+            'counts_after': counts_after,
+            'checksum_before': checksum_before,
+            'checksum_after': checksum_after,
+        },
+    )
     return imported_staging_tables
 
 

--- a/lib/etl_stages.py
+++ b/lib/etl_stages.py
@@ -37,8 +37,9 @@ from .etl_geocode import (
     upsert_geocoded_addresses,
 )
 from .parse_manifest import (
-    build_parse_xml_step_details,
+    finalize_parse_xml_step,
     upsert_parsed_etl_file,
+    upsert_promoted_etl_file,
 )
 from .parsers import oca_tag, parse_file
 
@@ -129,7 +130,7 @@ def download_selected_files(manifest, sftp, s3, priv_dir, s3_prefix, selection):
     manifest.upsert_step('download_files', 'completed')
 
 
-def parse_xml_to_staging(manifest, staging_db, priv_dir, parse_num_threads=8):
+def parse_xml_to_staging(manifest, staging_db, priv_dir, parse_num_threads=8, parse_fail_fast=False):
     def sort_by_date(file):
         r = re.search(r'(\d+.+)\.zip', file).group(0).replace('.', ' ')
         return r
@@ -165,10 +166,12 @@ def parse_xml_to_staging(manifest, staging_db, priv_dir, parse_num_threads=8):
         total_cases_failed += failed
         if failed > 0:
             files_with_failures += 1
-    manifest.upsert_step(
-        'parse_xml',
-        'completed',
-        details=build_parse_xml_step_details(total_cases_failed, files_with_failures),
+
+    finalize_parse_xml_step(
+        manifest,
+        total_cases_failed,
+        files_with_failures,
+        parse_fail_fast=parse_fail_fast,
     )
 
 
@@ -292,7 +295,8 @@ def import_and_promote_staging(manifest, db, pub_dir, s3_args, s3_prefix, select
     promote_staging_to_main(db)
     for selected_name in selection.selected_zip_files:
         source = 'sftp' if selected_name in selection.new_file_set else 's3_private'
-        manifest.upsert_file(selected_name, source=source, status='completed', stage='promote')
+        parse_details = manifest.file_details_by_name.get(selected_name, {})
+        upsert_promoted_etl_file(manifest, selected_name, source, parse_details)
     manifest.upsert_step('promote_staging', 'completed')
     return imported_staging_tables
 

--- a/lib/parse_manifest.py
+++ b/lib/parse_manifest.py
@@ -1,0 +1,36 @@
+"""Manifest details for per-zip parse results (no heavy ETL imports)."""
+
+
+def build_parsed_file_details(extract_date, parse_result):
+    return {
+        'extract_date': extract_date,
+        'cases_seen': parse_result.cases_seen,
+        'cases_parsed_ok': parse_result.cases_parsed_ok,
+        'cases_failed': parse_result.cases_failed,
+        'error_samples': parse_result.error_samples,
+    }
+
+
+def upsert_parsed_etl_file(manifest, file_name, parse_result, extract_date):
+    """Record per-zip parse counters on etl_files (status parsed)."""
+    details = build_parsed_file_details(extract_date, parse_result)
+    upsert_kwargs = {
+        'file_name': file_name,
+        'source': 'local',
+        'status': 'parsed',
+        'stage': 'parse',
+        'details': details,
+    }
+    if parse_result.cases_failed > 0:
+        upsert_kwargs['error'] = (
+            f"{parse_result.cases_failed} of {parse_result.cases_seen} cases failed to parse"
+        )
+    manifest.upsert_file(**upsert_kwargs)
+    return parse_result.cases_failed
+
+
+def build_parse_xml_step_details(total_cases_failed, files_with_failures):
+    return {
+        'total_cases_failed': total_cases_failed,
+        'files_with_failures': files_with_failures,
+    }

--- a/lib/parse_manifest.py
+++ b/lib/parse_manifest.py
@@ -1,6 +1,16 @@
 """Manifest details for per-zip parse results (no heavy ETL imports)."""
 
 
+class ParseFailFastError(RuntimeError):
+    """Raised when PARSE_FAIL_FAST is set and any zip has case-level parse failures."""
+
+
+def cases_failed_from_details(details):
+    if not details:
+        return 0
+    return int(details.get('cases_failed') or 0)
+
+
 def build_parsed_file_details(extract_date, parse_result):
     return {
         'extract_date': extract_date,
@@ -34,3 +44,66 @@ def build_parse_xml_step_details(total_cases_failed, files_with_failures):
         'total_cases_failed': total_cases_failed,
         'files_with_failures': files_with_failures,
     }
+
+
+def upsert_promoted_etl_file(manifest, file_name, source, parse_details):
+    """Mark file completed after promote only when parse had zero failures."""
+    cases_failed = cases_failed_from_details(parse_details)
+    if cases_failed > 0:
+        details = dict(parse_details)
+        details['parse_complete'] = False
+        manifest.upsert_file(
+            file_name,
+            source=source,
+            status='parsed',
+            stage='parse',
+            details=details,
+        )
+        return False
+    manifest.upsert_file(
+        file_name,
+        source=source,
+        status='completed',
+        stage='promote',
+        details=parse_details,
+    )
+    return True
+
+
+def file_names_needing_reprocess(file_details_by_name):
+    return sorted(
+        name
+        for name, details in file_details_by_name.items()
+        if cases_failed_from_details(details) > 0
+    )
+
+
+def finalize_parse_xml_step(manifest, total_cases_failed, files_with_failures, parse_fail_fast=False):
+    """Complete or fail the parse_xml manifest step; optionally abort before export/promote."""
+    step_details = build_parse_xml_step_details(total_cases_failed, files_with_failures)
+    if parse_fail_fast and total_cases_failed > 0:
+        for file_name, details in manifest.file_details_by_name.items():
+            if cases_failed_from_details(details) > 0:
+                manifest.upsert_file(
+                    file_name,
+                    source='local',
+                    status='failed',
+                    stage='parse',
+                    details=details,
+                    error=ParseFailFastError(
+                        f"{details.get('cases_failed', 0)} case(s) failed in {file_name}"
+                    ),
+                )
+        manifest.upsert_step(
+            'parse_xml',
+            'failed',
+            details=step_details,
+            error=ParseFailFastError(
+                f"PARSE_FAIL_FAST: {total_cases_failed} case failure(s) across "
+                f"{files_with_failures} file(s)"
+            ),
+        )
+        raise ParseFailFastError(
+            f"PARSE_FAIL_FAST: aborting before export/promote ({total_cases_failed} case failure(s))"
+        )
+    manifest.upsert_step('parse_xml', 'completed', details=step_details)

--- a/lib/parse_write_buffer.py
+++ b/lib/parse_write_buffer.py
@@ -61,6 +61,8 @@ class StagingWriteBuffer:
         self._inserts: dict[str, list[tuple | None]] = {}
         self._cases_in_window = 0
         self._flush_count = 0
+        self._in_case_window = False
+        self._case_mark: tuple[int, dict[str, int]] | None = None
 
     def _pending_insert_count(self) -> int:
         return sum(len(rows) for rows in self._inserts.values())
@@ -70,8 +72,46 @@ class StagingWriteBuffer:
 
     def queue_insert(self, sql: str, params: tuple | None) -> None:
         self._inserts.setdefault(sql, []).append(params)
-        if self._pending_insert_count() >= self.config.batch_size:
+        if (
+            not self._in_case_window
+            and self._pending_insert_count() >= self.config.batch_size
+        ):
             self.flush(reason='batch_size')
+
+    def begin_case(self) -> None:
+        """Start a whole-case write window (metadata + children)."""
+        self._case_mark = (
+            len(self._deletes),
+            {sql: len(rows) for sql, rows in self._inserts.items()},
+        )
+        self._in_case_window = True
+
+    def discard_case(self) -> None:
+        """Drop queued writes for the current case without executing them."""
+        if not self._in_case_window:
+            return
+        mark = self._case_mark
+        if mark is not None:
+            del_len, insert_lens = mark
+            del self._deletes[del_len:]
+            for sql in list(self._inserts):
+                prev = insert_lens.get(sql, 0)
+                rows = self._inserts[sql]
+                if prev >= len(rows):
+                    del self._inserts[sql]
+                else:
+                    del rows[prev:]
+                    if not rows:
+                        del self._inserts[sql]
+        self._case_mark = None
+        self._in_case_window = False
+
+    def commit_case(self) -> None:
+        """End a successful case window and apply cross-case cadence flush."""
+        if self._in_case_window:
+            self._case_mark = None
+            self._in_case_window = False
+        self.on_case_complete()
 
     def on_case_complete(self) -> None:
         self._cases_in_window += 1

--- a/lib/parsers.py
+++ b/lib/parsers.py
@@ -554,14 +554,16 @@ def parse_case(case, db, extract_date):
     :param db: a DuckDB object
     :param extract_date: date of extract
     """
-    
+    buffer = getattr(db, 'write_buffer', None)
+    if buffer is not None:
+        buffer.begin_case()
+
     update_metadata(case, db, extract_date)
 
     # If this case is flagged for removal, skip the parsing steps
     if is_case_to_delete(case):
-        buffer = getattr(db, 'write_buffer', None)
         if buffer is not None:
-            buffer.on_case_complete()
+            buffer.commit_case()
         return
 
     parse_index(case, db)
@@ -575,9 +577,8 @@ def parse_case(case, db, extract_date):
     parse_judgments(case, db)
     parse_warrants(case, db)
 
-    buffer = getattr(db, 'write_buffer', None)
     if buffer is not None:
-        buffer.on_case_complete()
+        buffer.commit_case()
 
 
 def _worker_thread(case_queue, db_queue, extract_date, thread_id, stats: ParseFileResult):
@@ -610,7 +611,9 @@ def _worker_thread(case_queue, db_queue, extract_date, thread_id, stats: ParseFi
                         e,
                         exc_info=True,
                     )
-                flush_write_buffer(thread_db, reason='parse_error')
+                buffer = getattr(thread_db, 'write_buffer', None)
+                if buffer is not None:
+                    buffer.discard_case()
                 stats.record_failed(str(e))
             finally:
                 # Clear the case copy from memory

--- a/lib/parsers.py
+++ b/lib/parsers.py
@@ -1,6 +1,7 @@
 import logging
 import queue
 import threading
+from dataclasses import dataclass, field
 
 from lxml import etree
 
@@ -9,6 +10,41 @@ from .parse_write_buffer import attach_write_buffer, flush_write_buffer, staging
 logger = logging.getLogger(__name__)
 
 PARSE_PROGRESS_INTERVAL = 1000
+MAX_PARSE_ERROR_SAMPLES = 10
+MAX_PARSE_ERROR_SAMPLE_LEN = 500
+
+
+@dataclass
+class ParseFileResult:
+    """Per-zip parse health counters (thread-safe)."""
+
+    cases_seen: int = 0
+    cases_parsed_ok: int = 0
+    cases_failed: int = 0
+    error_samples: list[str] = field(default_factory=list)
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False, compare=False)
+
+    def record_seen(self) -> None:
+        with self._lock:
+            self.cases_seen += 1
+
+    def record_ok(self) -> None:
+        with self._lock:
+            self.cases_parsed_ok += 1
+
+    def record_failed(self, error: str) -> None:
+        sample = _truncate_parse_error(str(error))
+        with self._lock:
+            self.cases_failed += 1
+            if len(self.error_samples) < MAX_PARSE_ERROR_SAMPLES:
+                self.error_samples.append(sample)
+
+
+def _truncate_parse_error(message: str) -> str:
+    if len(message) <= MAX_PARSE_ERROR_SAMPLE_LEN:
+        return message
+    return message[: MAX_PARSE_ERROR_SAMPLE_LEN - 3] + '...'
+
 
 NAMESPACE = '{http://www.example.org/LandlordTenantExtractSchema}'
 
@@ -22,6 +58,11 @@ def oca_tag(tag):
 
 INDEX_NUMBER_ID_TAG = oca_tag('IndexNumberId')
 DELETE_TAG = oca_tag('Delete')
+
+
+def _index_number_id_from_case(case) -> str | None:
+    elem = case.find(INDEX_NUMBER_ID_TAG)
+    return None if elem is None else elem.text
 
 
 def is_case_to_delete(case):
@@ -539,7 +580,7 @@ def parse_case(case, db, extract_date):
         buffer.on_case_complete()
 
 
-def _worker_thread(case_queue, db_queue, extract_date, thread_id):
+def _worker_thread(case_queue, db_queue, extract_date, thread_id, stats: ParseFileResult):
     """Worker thread that processes cases from the queue"""
     while True:
         try:
@@ -551,9 +592,26 @@ def _worker_thread(case_queue, db_queue, extract_date, thread_id):
             thread_db = db_queue.get()
             try:
                 parse_case(case, thread_db, extract_date)
+                stats.record_ok()
             except Exception as e:
-                print(f"Thread {thread_id}: Error parsing case: {e}")
+                index_id = _index_number_id_from_case(case)
+                if index_id:
+                    logger.warning(
+                        "Parse case failed thread=%s indexnumberid=%s: %s",
+                        thread_id,
+                        index_id,
+                        e,
+                        exc_info=True,
+                    )
+                else:
+                    logger.warning(
+                        "Parse case failed thread=%s: %s",
+                        thread_id,
+                        e,
+                        exc_info=True,
+                    )
                 flush_write_buffer(thread_db, reason='parse_error')
+                stats.record_failed(str(e))
             finally:
                 # Clear the case copy from memory
                 case.clear()
@@ -565,7 +623,7 @@ def _worker_thread(case_queue, db_queue, extract_date, thread_id):
             case_queue.task_done()
 
 
-def parse_file(xml_file, staging_db, extract_date, num_threads=8):
+def parse_file(xml_file, staging_db, extract_date, num_threads=8, file_name=None):
     """
     Parse XML file with multiple threads
 
@@ -573,9 +631,12 @@ def parse_file(xml_file, staging_db, extract_date, num_threads=8):
     :param staging_db: DuckDB database object
     :param extract_date: date of extract
     :param num_threads: number of worker threads (increasing this doesn't speed up much, bottleneck is the database writes)
+    :param file_name: basename for summary logging (optional)
+    :return: ParseFileResult with per-zip counters
     """
     from .duckdb_database import DuckDB
 
+    stats = ParseFileResult()
     case_queue = queue.Queue(maxsize=num_threads * 10)
     db_queue = queue.Queue()
 
@@ -588,8 +649,8 @@ def parse_file(xml_file, staging_db, extract_date, num_threads=8):
     threads = []
     for i in range(num_threads):
         t = threading.Thread(
-            target=_worker_thread, 
-            args=(case_queue, db_queue, extract_date, i)
+            target=_worker_thread,
+            args=(case_queue, db_queue, extract_date, i, stats),
         )
         t.start()
         threads.append(t)
@@ -597,14 +658,12 @@ def parse_file(xml_file, staging_db, extract_date, num_threads=8):
     # Parse XML and feed cases to queue
     context = etree.iterparse(xml_file, tag=oca_tag('Index'))
     
-    
-    total_cases = 0
     for _, case in context:
         case_copy = etree.fromstring(etree.tostring(case))
         case_queue.put(case_copy)
-        total_cases += 1
-        if total_cases % PARSE_PROGRESS_INTERVAL == 0:
-            logger.info("Parsed %s cases", total_cases)
+        stats.record_seen()
+        if stats.cases_seen % PARSE_PROGRESS_INTERVAL == 0:
+            logger.info("Parsed %s cases", stats.cases_seen)
 
         # Clear the case element to free memory
         case.clear()
@@ -624,6 +683,14 @@ def parse_file(xml_file, staging_db, extract_date, num_threads=8):
         thread_db = db_queue.get()
         flush_write_buffer(thread_db)
         thread_db.close()
-    
-    logger.info("Processed %s cases with %s threads", total_cases, num_threads)
+
+    label = file_name or getattr(xml_file, 'name', None) or 'unknown'
+    logger.info(
+        "Parse zip summary file=%s seen=%d ok=%d failed=%d",
+        label,
+        stats.cases_seen,
+        stats.cases_parsed_ok,
+        stats.cases_failed,
+    )
+    return stats
 

--- a/oca_update.py
+++ b/oca_update.py
@@ -27,6 +27,7 @@ def parse_args():
 	parser.add_argument('--s3-prefix', default=os.environ.get('S3_PREFIX', ''), help='Optional S3 prefix namespace for private/public files')
 	parser.add_argument('--reprocess-glob', default=os.environ.get('REPROCESS_GLOB', ''), help='Filename glob for S3 private zip reprocessing')
 	parser.add_argument('--force-reprocess', action='store_true', default=parse_bool(os.environ.get('FORCE_REPROCESS')), help='Reprocess matched files even if already in S3 private backup')
+	parser.add_argument('--parse-fail-fast', action='store_true', default=parse_bool(os.environ.get('PARSE_FAIL_FAST')), help='Abort run before export/promote when any case-level parse failures occur')
 	parser.add_argument('--geocode-workers', type=int, default=parse_optional_int(os.environ.get('GEOCODE_WORKERS')), help='Worker process count for geocode pool')
 	parser.add_argument('--census-batch-chunk-size', type=int, default=int(os.environ.get('CENSUS_BATCH_CHUNK_SIZE', '2500')), help='Chunk size for census batch geocoder input')
 	parser.add_argument('--csv-row-check-chunk-size', type=int, default=int(os.environ.get('CSV_ROW_CHECK_CHUNK_SIZE', '1000')), help='Chunk size used for constant-memory CSV non-empty checks')
@@ -75,6 +76,7 @@ def main():
 		'geocode_workers': args.geocode_workers,
 		'census_batch_chunk_size': args.census_batch_chunk_size,
 		'csv_row_check_chunk_size': args.csv_row_check_chunk_size,
+		'parse_fail_fast': args.parse_fail_fast,
 	}
 
 	oca_etl(db_args, sftp_args, s3_args, mode, remote_db_args, runtime_args)

--- a/tests/test_parse_failure_manifest.py
+++ b/tests/test_parse_failure_manifest.py
@@ -1,0 +1,210 @@
+"""Parse failure counters and manifest details (Task 1 observability)."""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import unittest
+import zipfile
+from unittest.mock import patch
+
+from lib.duckdb_database import DuckDB
+from lib.etl_constants import DATA_FILENAME
+from lib.parse_manifest import build_parse_xml_step_details, upsert_parsed_etl_file
+from lib.parse_write_buffer import attach_write_buffer, flush_write_buffer
+from lib.parsers import (
+    MAX_PARSE_ERROR_SAMPLES,
+    MAX_PARSE_ERROR_SAMPLE_LEN,
+    ParseFileResult,
+    parse_case,
+    parse_file,
+)
+
+from parser_xml_fixtures import build_extract_xml, write_test_zip
+
+
+class FakeManifest:
+    def __init__(self):
+        self.file_upserts = []
+        self.step_upserts = []
+
+    def upsert_file(self, file_name, source, status, stage=None, details=None, error=None):
+        self.file_upserts.append({
+            'file_name': file_name,
+            'source': source,
+            'status': status,
+            'stage': stage,
+            'details': details or {},
+            'error': error,
+        })
+
+    def upsert_step(self, step_name, status, details=None, error=None):
+        self.step_upserts.append({
+            'step_name': step_name,
+            'status': status,
+            'details': details or {},
+            'error': error,
+        })
+
+
+def _init_staging_db(path: str) -> DuckDB:
+    db = DuckDB(path)
+    db.execute_sql_file('lib/sql/create_tables_staging_duckdb.sql')
+    attach_write_buffer(db)
+    return db
+
+
+def _parse_zip_bytes(xml_bytes: bytes, db: DuckDB, extract_date: str = '2024-03-08') -> ParseFileResult:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w') as zf:
+        zf.writestr(DATA_FILENAME, xml_bytes)
+    buf.seek(0)
+    with zipfile.ZipFile(buf, 'r') as zf:
+        with zf.open(DATA_FILENAME) as xml_file:
+            return parse_file(xml_file, db, extract_date, num_threads=1)
+
+
+class ParseFileResultTests(unittest.TestCase):
+    def test_cases_seen_matches_index_count(self):
+        xml_bytes = build_extract_xml(12, child_profile='weekly')
+        with tempfile.TemporaryDirectory() as tmp:
+            db = _init_staging_db(os.path.join(tmp, 'staging.duckdb'))
+            try:
+                result = _parse_zip_bytes(xml_bytes, db)
+                flush_write_buffer(db)
+            finally:
+                db.close()
+
+        self.assertEqual(result.cases_seen, 12)
+        self.assertEqual(result.cases_parsed_ok, 12)
+        self.assertEqual(result.cases_failed, 0)
+        self.assertEqual(result.error_samples, [])
+
+    def test_injected_failures_increment_counters_and_samples(self):
+        xml_bytes = build_extract_xml(5, child_profile='weekly')
+        fail_ids = {2, 4}
+        seen = {'n': 0}
+
+        def parse_case_maybe_fail(case, db, extract_date):
+            seen['n'] += 1
+            if seen['n'] in fail_ids:
+                raise RuntimeError(f'injected failure case {seen["n"]}')
+            parse_case(case, db, extract_date)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = _init_staging_db(os.path.join(tmp, 'staging.duckdb'))
+            try:
+                with patch('lib.parsers.parse_case', parse_case_maybe_fail):
+                    result = _parse_zip_bytes(xml_bytes, db)
+                flush_write_buffer(db)
+            finally:
+                db.close()
+
+        self.assertEqual(result.cases_seen, 5)
+        self.assertEqual(result.cases_parsed_ok, 3)
+        self.assertEqual(result.cases_failed, 2)
+        self.assertEqual(len(result.error_samples), 2)
+        self.assertTrue(all('injected failure' in s for s in result.error_samples))
+
+    def test_error_samples_capped_at_ten(self):
+        xml_bytes = build_extract_xml(15, child_profile='weekly')
+        seen = {'n': 0}
+
+        def parse_case_always_fail(case, db, extract_date):
+            seen['n'] += 1
+            raise RuntimeError('always fail')
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = _init_staging_db(os.path.join(tmp, 'staging.duckdb'))
+            try:
+                with patch('lib.parsers.parse_case', parse_case_always_fail):
+                    result = _parse_zip_bytes(xml_bytes, db)
+            finally:
+                db.close()
+
+        self.assertEqual(result.cases_failed, 15)
+        self.assertEqual(len(result.error_samples), MAX_PARSE_ERROR_SAMPLES)
+
+    def test_error_sample_truncation(self):
+        long_msg = 'x' * (MAX_PARSE_ERROR_SAMPLE_LEN + 50)
+        stats = ParseFileResult()
+        stats.record_failed(long_msg)
+        self.assertEqual(len(stats.error_samples[0]), MAX_PARSE_ERROR_SAMPLE_LEN)
+        self.assertTrue(stats.error_samples[0].endswith('...'))
+
+    def test_parse_logs_indexnumberid_on_failure(self):
+        xml_bytes = build_extract_xml(1, child_profile='weekly')
+        case_id = 'LT-BENCH-000000'
+
+        def parse_case_fail(case, db, extract_date):
+            raise RuntimeError('log test failure')
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = _init_staging_db(os.path.join(tmp, 'staging.duckdb'))
+            try:
+                with patch('lib.parsers.parse_case', parse_case_fail):
+                    with self.assertLogs('lib.parsers', level='WARNING') as logs:
+                        _parse_zip_bytes(xml_bytes, db)
+            finally:
+                db.close()
+
+        combined = '\n'.join(logs.output)
+        self.assertIn('indexnumberid=', combined)
+        self.assertIn(case_id, combined)
+
+
+class ParseManifestUpsertTests(unittest.TestCase):
+    def test_upsert_parsed_etl_file_and_step_aggregate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = _init_staging_db(os.path.join(tmp, 'staging.duckdb'))
+            manifest = FakeManifest()
+            fail_on = {3}
+
+            def parse_case_maybe_fail(case, db, extract_date):
+                index_elem = case.find(
+                    '{http://www.example.org/LandlordTenantExtractSchema}IndexNumberId'
+                )
+                case_num = int(index_elem.text.rsplit('-', 1)[-1]) if index_elem is not None else 0
+                if case_num in fail_on:
+                    raise RuntimeError('manifest test failure')
+                parse_case(case, db, extract_date)
+
+            xml_bytes = build_extract_xml(6, child_profile='weekly')
+            try:
+                with patch('lib.parsers.parse_case', parse_case_maybe_fail):
+                    result = _parse_zip_bytes(xml_bytes, db)
+                flush_write_buffer(db)
+            finally:
+                db.close()
+
+        upsert_parsed_etl_file(
+            manifest,
+            'LandlordTenant.Incr.2024-03-08.zip',
+            result,
+            '2024-03-08',
+        )
+        manifest.upsert_step(
+            'parse_xml',
+            'completed',
+            details=build_parse_xml_step_details(result.cases_failed, 1),
+        )
+
+        self.assertEqual(len(manifest.file_upserts), 1)
+        upsert = manifest.file_upserts[0]
+        details = upsert['details']
+        self.assertEqual(upsert['status'], 'parsed')
+        self.assertEqual(details['cases_seen'], 6)
+        self.assertEqual(details['cases_parsed_ok'], 5)
+        self.assertEqual(details['cases_failed'], 1)
+        self.assertEqual(len(details['error_samples']), 1)
+        self.assertEqual(details['extract_date'], '2024-03-08')
+        self.assertIn('1 of 6 cases failed', upsert['error'])
+
+        step_details = manifest.step_upserts[0]['details']
+        self.assertEqual(step_details['total_cases_failed'], 1)
+        self.assertEqual(step_details['files_with_failures'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_parse_failure_manifest.py
+++ b/tests/test_parse_failure_manifest.py
@@ -11,7 +11,14 @@ from unittest.mock import patch
 
 from lib.duckdb_database import DuckDB
 from lib.etl_constants import DATA_FILENAME
-from lib.parse_manifest import build_parse_xml_step_details, upsert_parsed_etl_file
+from lib.parse_manifest import (
+    ParseFailFastError,
+    build_parse_xml_step_details,
+    cases_failed_from_details,
+    finalize_parse_xml_step,
+    upsert_parsed_etl_file,
+    upsert_promoted_etl_file,
+)
 from lib.parse_write_buffer import attach_write_buffer, flush_write_buffer
 from lib.parsers import (
     MAX_PARSE_ERROR_SAMPLES,
@@ -28,8 +35,11 @@ class FakeManifest:
     def __init__(self):
         self.file_upserts = []
         self.step_upserts = []
+        self.file_details_by_name = {}
 
     def upsert_file(self, file_name, source, status, stage=None, details=None, error=None):
+        if details is not None:
+            self.file_details_by_name[file_name] = dict(details)
         self.file_upserts.append({
             'file_name': file_name,
             'source': source,
@@ -204,6 +214,73 @@ class ParseManifestUpsertTests(unittest.TestCase):
         step_details = manifest.step_upserts[0]['details']
         self.assertEqual(step_details['total_cases_failed'], 1)
         self.assertEqual(step_details['files_with_failures'], 1)
+
+
+class PromoteCompletedGateTests(unittest.TestCase):
+    def test_upsert_promoted_marks_completed_only_when_no_failures(self):
+        manifest = FakeManifest()
+        clean_details = {
+            'extract_date': '2024-03-08',
+            'cases_seen': 10,
+            'cases_parsed_ok': 10,
+            'cases_failed': 0,
+            'error_samples': [],
+        }
+        dirty_details = dict(clean_details)
+        dirty_details['cases_failed'] = 3
+        dirty_details['cases_parsed_ok'] = 7
+        dirty_details['error_samples'] = ['err']
+
+        self.assertTrue(upsert_promoted_etl_file(manifest, 'clean.zip', 'sftp', clean_details))
+        self.assertFalse(upsert_promoted_etl_file(manifest, 'dirty.zip', 's3_private', dirty_details))
+
+        clean_upsert = manifest.file_upserts[-2]
+        dirty_upsert = manifest.file_upserts[-1]
+        self.assertEqual(clean_upsert['status'], 'completed')
+        self.assertEqual(clean_upsert['stage'], 'promote')
+        self.assertNotIn('parse_complete', clean_upsert['details'])
+
+        self.assertEqual(dirty_upsert['status'], 'parsed')
+        self.assertEqual(dirty_upsert['stage'], 'parse')
+        self.assertFalse(dirty_upsert['details']['parse_complete'])
+        self.assertEqual(dirty_upsert['details']['cases_failed'], 3)
+
+    def test_cases_failed_from_details_coerces_missing(self):
+        self.assertEqual(cases_failed_from_details({}), 0)
+        self.assertEqual(cases_failed_from_details({'cases_failed': '2'}), 2)
+
+
+class ParseFailFastTests(unittest.TestCase):
+    def test_finalize_parse_fail_fast_marks_step_and_files_failed(self):
+        manifest = FakeManifest()
+        manifest.file_details_by_name = {
+            'bad.zip': {
+                'cases_seen': 5,
+                'cases_parsed_ok': 3,
+                'cases_failed': 2,
+                'error_samples': ['err'],
+            },
+            'good.zip': {
+                'cases_seen': 1,
+                'cases_parsed_ok': 1,
+                'cases_failed': 0,
+                'error_samples': [],
+            },
+        }
+
+        with self.assertRaises(ParseFailFastError):
+            finalize_parse_xml_step(manifest, 2, 1, parse_fail_fast=True)
+
+        self.assertEqual(manifest.step_upserts[-1]['status'], 'failed')
+        self.assertEqual(manifest.step_upserts[-1]['step_name'], 'parse_xml')
+        failed_names = {u['file_name'] for u in manifest.file_upserts if u['status'] == 'failed'}
+        self.assertEqual(failed_names, {'bad.zip'})
+
+    def test_lenient_finalize_completes_step_with_failures(self):
+        manifest = FakeManifest()
+        finalize_parse_xml_step(manifest, 3, 1, parse_fail_fast=False)
+        self.assertEqual(manifest.step_upserts[-1]['status'], 'completed')
+        self.assertEqual(manifest.step_upserts[-1]['details']['total_cases_failed'], 3)
 
 
 if __name__ == '__main__':

--- a/tests/test_parser_batching.py
+++ b/tests/test_parser_batching.py
@@ -121,6 +121,24 @@ class ParserBatchingSemanticsTests(unittest.TestCase):
 
 
 class ParseWriteBufferTests(unittest.TestCase):
+    def test_discard_case_drops_in_window_writes(self):
+        from lib.parse_write_buffer import StagingWriteBuffer
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = DuckDB(os.path.join(tmp, 'buf.duckdb'))
+            db.execute('CREATE TABLE t (id INTEGER, v VARCHAR)')
+            buffer = StagingWriteBuffer(
+                db,
+                ParseWriteConfig(enabled=True, batch_size=100, flush_every_n_cases=10),
+            )
+            buffer.begin_case()
+            buffer.queue_insert('INSERT INTO t VALUES (?, ?)', (1, 'orphan'))
+            buffer.discard_case()
+            buffer.flush()
+            count = db.execute('SELECT COUNT(*) FROM t').fetchone()[0]
+            db.close()
+        self.assertEqual(count, 0)
+
     def test_flush_order_deletes_before_inserts(self):
         from lib.parse_write_buffer import StagingWriteBuffer
 

--- a/tests/test_parser_regression_safety.py
+++ b/tests/test_parser_regression_safety.py
@@ -9,10 +9,11 @@ import unittest
 import zipfile
 from unittest.mock import patch
 
-from lib.duckdb_database import DuckDB, fetch_staging_row_counts
+from lib.duckdb_database import STAGING_TABLE_FAMILIES, DuckDB, fetch_staging_row_counts
 from lib.etl_constants import DATA_FILENAME
 from lib.etl_stages import export_staging_to_csv
 from lib.parse_write_buffer import ParseWriteConfig, StagingWriteBuffer, attach_write_buffer, flush_write_buffer
+from lib import parsers
 from lib.parsers import parse_case, parse_file
 
 from csv_checksums import md5_dir_csvs
@@ -25,6 +26,20 @@ def _init_staging_db(path: str) -> DuckDB:
     db.execute_sql_file('lib/sql/create_tables_staging_duckdb.sql')
     attach_write_buffer(db)
     return db
+
+
+def _staging_counts_for_index(db: DuckDB, index_id: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for table_name in STAGING_TABLE_FAMILIES:
+        try:
+            row = db.execute(
+                f'SELECT COUNT(*) FROM {table_name} WHERE indexnumberid = ?',
+                (index_id,),
+            ).fetchone()
+            counts[table_name] = int(row[0]) if row else 0
+        except Exception:
+            counts[table_name] = 0
+    return counts
 
 
 def _parse_zip_bytes(
@@ -125,7 +140,7 @@ class ColdRerunIdempotencyTests(unittest.TestCase):
 
 
 class ParserFailureRerunTests(unittest.TestCase):
-    def test_mid_file_failure_flush_then_rerun_matches_clean_parse(self):
+    def test_mid_file_failure_discard_then_rerun_matches_clean_parse(self):
         xml_bytes = build_extract_xml(20, child_profile='weekly')
         fail_on_case = 8
         seen = {'n': 0}
@@ -159,6 +174,34 @@ class ParserFailureRerunTests(unittest.TestCase):
                 dirty_db.close()
 
         self.assertEqual(clean_counts, recovery_counts)
+
+    def test_failed_mid_case_leaves_no_staging_footprint(self):
+        """Failure after metadata + partial children leaves no rows for that case."""
+        xml_bytes = build_extract_xml(12, child_profile='weekly')
+        fail_id = 'LT-BENCH-000005'
+        real_parse_index = parsers.parse_index
+
+        def parse_index_maybe_fail(case, db):
+            real_parse_index(case, db)
+            index_el = case.find(parsers.INDEX_NUMBER_ID_TAG)
+            if index_el is not None and index_el.text == fail_id:
+                raise RuntimeError('injected after metadata and index')
+
+        with tempfile.TemporaryDirectory() as tmp:
+            db = _init_staging_db(os.path.join(tmp, 'dirty.duckdb'))
+            try:
+                baseline = _staging_counts_for_index(db, fail_id)
+                with patch('lib.parsers.parse_index', parse_index_maybe_fail):
+                    _parse_zip_bytes(xml_bytes, db)
+                flush_write_buffer(db)
+                after_failure = _staging_counts_for_index(db, fail_id)
+                counts = fetch_staging_row_counts(db)
+            finally:
+                db.close()
+
+        self.assertEqual(baseline, {table: 0 for table in STAGING_TABLE_FAMILIES})
+        self.assertEqual(after_failure, baseline)
+        self.assertEqual(counts['oca_index_staging'], 11)
 
 
 class BatchBoundaryCorrectnessTests(unittest.TestCase):

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -199,3 +199,81 @@ class PromotionTableCountsTests(unittest.TestCase):
         counts = promotion_table_counts(db, tables=['oca_index', 'oca_causes'])
         self.assertEqual(counts, {'oca_index': 42, 'oca_causes': 42})
         self.assertEqual(db.sql_fetch_one.call_count, 2)
+
+
+class FakeManifest:
+    def __init__(self):
+        self.step_upserts = []
+        self.file_details_by_name = {}
+
+    def upsert_file(self, file_name, source, status, stage=None, details=None, error=None):
+        if details is not None:
+            self.file_details_by_name[file_name] = dict(details)
+
+    def upsert_step(self, step_name, status, details=None, error=None):
+        self.step_upserts.append({
+            'step_name': step_name,
+            'status': status,
+            'details': details or {},
+            'error': error,
+        })
+
+
+class ImportAndPromoteStagingObservabilityTests(unittest.TestCase):
+    @mock.patch('lib.etl_stages.upsert_promoted_etl_file')
+    @mock.patch('lib.etl_stages.promote_staging_to_main')
+    @mock.patch('lib.etl_stages.ensure_core_tables_exist')
+    @mock.patch('lib.etl_stages.staging_tables_with_rows', return_value=[])
+    @mock.patch('lib.etl_stages.promotion_table_counts')
+    @mock.patch('geosupport.Geosupport')
+    def test_promote_step_records_before_after_checksums(
+        self,
+        _geosupport_mock,
+        counts_mock,
+        _staging_rows_mock,
+        _ensure_tables_mock,
+        _promote_mock,
+        _upsert_file_mock,
+    ):
+        from lib.etl_stages import FileSelection, import_and_promote_staging
+
+        counts_before = {'oca_index': 100, 'oca_metadata': 100}
+        counts_after = {'oca_index': 150, 'oca_metadata': 150}
+        counts_mock.side_effect = [counts_before, counts_after]
+
+        manifest = FakeManifest()
+        db = mock.Mock()
+        selection = FileSelection(
+            selected_zip_files=['test.zip'],
+            skipped_reprocess_files=[],
+            new_file_set={'test.zip'},
+            reprocess_file_set=set(),
+            sftp_download_files=['test.zip'],
+            s3_download_files=[],
+        )
+
+        with mock.patch('lib.etl_stages.csv_has_rows', return_value=False):
+            import_and_promote_staging(
+                manifest,
+                db,
+                '/tmp/pub',
+                {'aws_bucket_name': 'b', 'aws_id': 'i', 'aws_key': 'k'},
+                '',
+                selection,
+                'public',
+            )
+
+        completed = [s for s in manifest.step_upserts if s['status'] == 'completed'][-1]
+        self.assertEqual(completed['step_name'], 'promote_staging')
+        details = completed['details']
+        self.assertEqual(details['counts_before'], counts_before)
+        self.assertEqual(details['counts_after'], counts_after)
+        self.assertEqual(
+            details['checksum_before'],
+            promotion_counts_checksum(counts_before),
+        )
+        self.assertEqual(
+            details['checksum_after'],
+            promotion_counts_checksum(counts_after),
+        )
+        self.assertEqual(counts_mock.call_count, 2)

--- a/tests/test_run_manifest.py
+++ b/tests/test_run_manifest.py
@@ -1,6 +1,7 @@
 import unittest
 
-from lib.etl import EtlRunManifest, completed_reprocess_files, select_data_files_to_process
+from lib.etl_run_manifest import EtlRunManifest, completed_reprocess_files
+from lib.etl_file_selection import select_data_files_to_process
 
 
 class FakeDb:
@@ -32,6 +33,21 @@ class RunManifestTests(unittest.TestCase):
         fake_db.fetch_all_result = [("file_a.zip",), ("file_b.zip",)]
         completed = completed_reprocess_files(fake_db, ["file_a.zip", "file_c.zip"])
         self.assertEqual(completed, {"file_a.zip", "file_b.zip"})
+        sql = fake_db.sql_calls[-1][1]
+        self.assertIn("cases_failed", sql)
+        self.assertIn("= 0", sql)
+
+    def test_completed_reprocess_files_excludes_files_with_case_failures(self):
+        """SQL must filter out completed rows where details.cases_failed > 0."""
+        fake_db = FakeDb()
+        fake_db.fetch_all_result = [("file_clean.zip",)]
+        completed = completed_reprocess_files(
+            fake_db,
+            ["file_clean.zip", "file_dirty.zip"],
+        )
+        self.assertEqual(completed, {"file_clean.zip"})
+        sql = fake_db.sql_calls[-1][1]
+        self.assertIn("COALESCE((ef.details->>'cases_failed')::int, 0) = 0", sql)
 
     def test_reprocess_without_force_skips_completed_files(self):
         new_files = ["LandlordTenant.Incr.2024-03-01.zip"]
@@ -47,6 +63,20 @@ class RunManifestTests(unittest.TestCase):
         )
         self.assertEqual(selected, ["LandlordTenant.Incr.2024-03-01.zip"])
 
+    def test_mark_run_completed_records_files_needing_reprocess(self):
+        fake_db = FakeDb()
+        manifest = EtlRunManifest(fake_db, 'public', '', '2', '', False)
+        manifest.mark_run_completed(
+            2,
+            1,
+            0,
+            files_needing_reprocess=['dirty.zip'],
+        )
+        sql = fake_db.sql_calls[-1][1]
+        self.assertIn('files_needing_reprocess', sql)
+        self.assertIn('dirty.zip', sql)
+        self.assertIn('processed_file_count = 1', sql)
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     unittest.main()

--- a/tests/test_runtime_controls.py
+++ b/tests/test_runtime_controls.py
@@ -30,6 +30,7 @@ class RuntimeControlTests(unittest.TestCase):
         self.assertEqual(runtime_args['s3_prefix'], '')
         self.assertEqual(runtime_args['reprocess_glob'], '')
         self.assertFalse(runtime_args['force_reprocess'])
+        self.assertFalse(runtime_args['parse_fail_fast'])
 
     @patch('oca_update.oca_etl')
     def test_main_non_default_schema_smoke_path(self, oca_etl_mock):
@@ -47,6 +48,7 @@ class RuntimeControlTests(unittest.TestCase):
             'S3_PREFIX': 'refactor/dev',
             'REPROCESS_GLOB': 'LandlordTenant.Incr.2024-*.zip',
             'FORCE_REPROCESS': 'true',
+            'PARSE_FAIL_FAST': 'true',
             'GEOCODE_WORKERS': '3',
             'CENSUS_BATCH_CHUNK_SIZE': '2000',
             'CSV_ROW_CHECK_CHUNK_SIZE': '500',
@@ -60,6 +62,7 @@ class RuntimeControlTests(unittest.TestCase):
         self.assertEqual(runtime_args['reprocess_glob'], 'LandlordTenant.Incr.2024-*.zip')
         self.assertTrue(runtime_args['force_reprocess'])
         self.assertEqual(runtime_args['geocode_workers'], 3)
+        self.assertTrue(runtime_args['parse_fail_fast'])
 
     @patch('lib.database.psycopg2.connect')
     def test_database_sets_search_path_for_schema(self, connect_mock):


### PR DESCRIPTION
Previously failures during xml case parsing were printed but not handled in any other way so it would be easy to miss the problem. This adds some additional safety measures to make sure it's clear when there is a parsing failure and when it needs to be corrected. By default the rest of the file(s) continue the rest of the pipeline, since I think it's better to update with a few cases missing and then reprocess later to correct it rather than to fail right away when there might not be time to reprocess before the data is needed (context is justfix sends out an email monday morning that uses the data) and if multiple files are being processed at once then later only the single fail that had the parsing failure can be rerun.

Details on the failures are recorded in the "manifest" tables that were already added as part of the refactor. 